### PR TITLE
Downgrade amazon-s3-and-cloudfront

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "johnpbloch/wordpress": "4.3.1",
     "private/meta-box-group": "1.0.1",
     "private/wpfront-user-role-editor-personal-pro": "2.12.1",
-    "wpackagist-plugin/amazon-s3-and-cloudfront": "0.9.8",
+    "wpackagist-plugin/amazon-s3-and-cloudfront": "0.9.9",
     "wpackagist-plugin/amazon-web-services": "0.3.4",
     "wpackagist-plugin/easy-wp-smtp": "1.2.1",
     "wpackagist-plugin/google-calendar-events": "2.4.0",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "johnpbloch/wordpress": "4.3.1",
     "private/meta-box-group": "1.0.1",
     "private/wpfront-user-role-editor-personal-pro": "2.12.1",
-    "wpackagist-plugin/amazon-s3-and-cloudfront": "0.9.9",
+    "wpackagist-plugin/amazon-s3-and-cloudfront": "0.9.7",
     "wpackagist-plugin/amazon-web-services": "0.3.4",
     "wpackagist-plugin/easy-wp-smtp": "1.2.1",
     "wpackagist-plugin/google-calendar-events": "2.4.0",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "johnpbloch/wordpress": "4.3.1",
     "private/meta-box-group": "1.0.1",
     "private/wpfront-user-role-editor-personal-pro": "2.12.1",
-    "wpackagist-plugin/amazon-s3-and-cloudfront": "0.9.7",
+    "wpackagist-plugin/amazon-s3-and-cloudfront": "0.9.6",
     "wpackagist-plugin/amazon-web-services": "0.3.4",
     "wpackagist-plugin/easy-wp-smtp": "1.2.1",
     "wpackagist-plugin/google-calendar-events": "2.4.0",


### PR DESCRIPTION
Versions since 0.9.6 use new restrictions on media links that break our media library. We'll have to test new uploads and potentially modify the db before upgrading to current.