### PR TITLE
Limit wordpress fastcgi cache to 10m

### DIFF
--- a/nginx/conf.d/fastcgi_cache.conf
+++ b/nginx/conf.d/fastcgi_cache.conf
@@ -1,4 +1,4 @@
-fastcgi_cache_path /var/run/nginx-cache levels=1:2 keys_zone=WORDPRESS:100m inactive=60m;
+fastcgi_cache_path /var/run/nginx-cache levels=1:2 keys_zone=WORDPRESS:10m inactive=60m;
 fastcgi_cache_key "$request_method$request_uri";
 fastcgi_cache_use_stale error timeout invalid_header http_500;
 fastcgi_ignore_headers Cache-Control Expires Set-Cookie;


### PR DESCRIPTION
The former value of 100m was greater than the /tmp directory in which
/var/run/nginx-cache was kept.