### PR TITLE
Condition for displaying uncategorized contact block as default

### DIFF
--- a/wp/wp-content/themes/phila.gov-theme/functions.php
+++ b/wp/wp-content/themes/phila.gov-theme/functions.php
@@ -548,7 +548,11 @@ function get_department_menu() {
 
 function phila_get_dept_contact_blocks(){
   $categories = get_the_category();
-  $default_sidebar = 'sidebar-uncategorized-1';
+  $default_category_slug = 'uncategorized';
+  $default_category_object = get_category_by_slug($default_category_slug);
+  $default_category_id = $default_category_object->term_id;
+
+  $default_sidebar = 'sidebar-' . $default_category_slug .'-' . $default_category_id;
 
   if (count($categories)==1){
     foreach ( $categories as $category ) {

--- a/wp/wp-content/themes/phila.gov-theme/functions.php
+++ b/wp/wp-content/themes/phila.gov-theme/functions.php
@@ -546,7 +546,7 @@ function get_department_menu() {
   }
 }
 
-function phila_get_dept_contact_blocks(){
+function phila_get_dept_contact_blocks() {
   $categories = get_the_category();
   $default_category_slug = 'uncategorized';
   $default_category_object = get_category_by_slug($default_category_slug);
@@ -554,20 +554,18 @@ function phila_get_dept_contact_blocks(){
 
   $default_sidebar = 'sidebar-' . $default_category_slug .'-' . $default_category_id;
 
-  if (count($categories)==1){
+  if ( count($categories) == 1 ) {
     foreach ( $categories as $category ) {
       $cat_slug = $category->slug;
       $cat_id = $category->cat_ID;
       $current_sidebar_name = 'sidebar-' . $cat_slug .'-' . $cat_id;
     }
-    if(is_active_sidebar($current_sidebar_name)){
+    if(is_active_sidebar( $current_sidebar_name )) {
       dynamic_sidebar( $current_sidebar_name );
-    }
-    else{
+    } else {
       dynamic_sidebar( $default_sidebar );
     }
-  }
-  else{
+  } else {
     dynamic_sidebar( $default_sidebar );
   }
 

--- a/wp/wp-content/themes/phila.gov-theme/functions.php
+++ b/wp/wp-content/themes/phila.gov-theme/functions.php
@@ -548,12 +548,19 @@ function get_department_menu() {
 
 function phila_get_dept_contact_blocks(){
   $categories = get_the_category();
-  foreach ( $categories as $category ) {
-    $cat_slug = $category->slug;
-    $cat_id = $category->cat_ID;
-    $current_sidebar_name = 'sidebar-' . $cat_slug .'-' . $cat_id;
+
+  if (count($categories)==1){
+    foreach ( $categories as $category ) {
+      $cat_slug = $category->slug;
+      $cat_id = $category->cat_ID;
+      $current_sidebar_name = 'sidebar-' . $cat_slug .'-' . $cat_id;
+    }
+    dynamic_sidebar( $current_sidebar_name );
   }
-  dynamic_sidebar( $current_sidebar_name );
+  else{
+    dynamic_sidebar( 'uncategorized' );
+  }
+  
 }
 
 function phila_get_full_page_title(){

--- a/wp/wp-content/themes/phila.gov-theme/functions.php
+++ b/wp/wp-content/themes/phila.gov-theme/functions.php
@@ -548,6 +548,7 @@ function get_department_menu() {
 
 function phila_get_dept_contact_blocks(){
   $categories = get_the_category();
+  $default_sidebar = 'sidebar-uncategorized-1';
 
   if (count($categories)==1){
     foreach ( $categories as $category ) {
@@ -555,12 +556,17 @@ function phila_get_dept_contact_blocks(){
       $cat_id = $category->cat_ID;
       $current_sidebar_name = 'sidebar-' . $cat_slug .'-' . $cat_id;
     }
-    dynamic_sidebar( $current_sidebar_name );
+    if(is_active_sidebar($current_sidebar_name)){
+      dynamic_sidebar( $current_sidebar_name );
+    }
+    else{
+      dynamic_sidebar( $default_sidebar );
+    }
   }
   else{
-    dynamic_sidebar( 'uncategorized' );
+    dynamic_sidebar( $default_sidebar );
   }
-  
+
 }
 
 function phila_get_full_page_title(){


### PR DESCRIPTION
phila_get_dept_contact_blocks() checks if the page is categorized properly (only 1 category), if not display the uncategorized sidebar as the contact block.