### PR TITLE
Include php7.0-zlib for unzipping plugins

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 export DEBIAN_FRONTEND=noninteractive
 sudo add-apt-repository -y ppa:ondrej/php
 sudo apt-get update
-sudo -E apt-get install -y jq nginx php7.0-cli php7.0-curl php7.0-fpm php7.0-gd php7.0-mysql
+sudo -E apt-get install -y jq nginx php7.0-cli php7.0-curl php7.0-fpm php7.0-gd php7.0-mysql php7.0-zlib
 
 echo "Installing wp-cli"
 curl -sS https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar | sudo tee /usr/local/bin/wp > /dev/null


### PR DESCRIPTION
Seeing this error in deploy at private plugins step:

```
Abort class-pclzip.php : Missing zlib extensions
```
