### PR TITLE
Corrects minor markup errors on front-page and header

### DIFF
--- a/wp/wp-content/themes/phila.gov-theme/front-page.php
+++ b/wp/wp-content/themes/phila.gov-theme/front-page.php
@@ -33,7 +33,7 @@ get_header(); ?>
                     <i class="fa fa-circle fa-stack-2x"></i>
                     <i class="fa fa-credit-card fa-stack-1x fa-inverse"></i>
                   </span>
-                  <p>Pay a Bill<p>
+                  <p>Pay a Bill</p>
                   <span class="accessible"> Opens in new window</span>
                 </a>
               </div>

--- a/wp/wp-content/themes/phila.gov-theme/header.php
+++ b/wp/wp-content/themes/phila.gov-theme/header.php
@@ -51,7 +51,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <div class="row site-branding">
       <div class="small-16 columns">
         <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" class="logo mbn-mu">
-          <img src="//cityofphiladelphia.github.io/patterns/images/city-of-philadelphia-white.png"></a>
+          <img src="//cityofphiladelphia.github.io/patterns/images/city-of-philadelphia-white.png" alt=""></a>
           <h1 class="site-title"><?php bloginfo( 'name' ); ?></h1>
           <h2 class="site-description"><?php bloginfo( 'description' ); ?></h2>
         </div>

--- a/wp/wp-content/themes/phila.gov-theme/header.php
+++ b/wp/wp-content/themes/phila.gov-theme/header.php
@@ -51,7 +51,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <div class="row site-branding">
       <div class="small-16 columns">
         <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" class="logo mbn-mu">
-          <img src="//cityofphiladelphia.github.io/patterns/images/city-of-philadelphia-white.png" alt=""></a>
+          <img src="//cityofphiladelphia.github.io/patterns/images/city-of-philadelphia-white.png" alt="home page"></a>
           <h1 class="site-title"><?php bloginfo( 'name' ); ?></h1>
           <h2 class="site-description"><?php bloginfo( 'description' ); ?></h2>
         </div>


### PR DESCRIPTION
Noticed a few minor issues while running the alpha homepage through the W3C Validator. 

- Closes open paragraph tag
- Add alt tag to logo (w/ appropriate content)