### PR TITLE
Department pages of any status can be included in first-child redirects

### DIFF
--- a/wp/wp-content/themes/phila.gov-theme/single-department_page.php
+++ b/wp/wp-content/themes/phila.gov-theme/single-department_page.php
@@ -11,7 +11,7 @@ $children = get_posts( array(
   'orderby' => 'menu_order',
   'order' => 'ASC',
   'post_type' => 'department_page',
-  'post_status' => 'publish'
+  'post_status' => 'any'
 ));
 
 $ancestors = get_post_ancestors($post);


### PR DESCRIPTION
This will allow pages that are private or in draft mode to function the way they would if they were live on the site. 