### PR TITLE
Add util function to get current cat slug

### DIFF
--- a/wp/wp-content/themes/phila.gov-theme/functions.php
+++ b/wp/wp-content/themes/phila.gov-theme/functions.php
@@ -524,6 +524,14 @@ function phila_util_get_current_cat_name(){
   }
 }
 
+//spits out a nice version of the department category slug
+function phila_util_get_current_cat_slug(){
+  $category = get_the_category();
+  foreach( $category as $cat){
+    return $cat->slug;
+  }
+}
+
 function phila_get_department_menu() {
   /*
     Set the menus. We use categories to drive functionality.

--- a/wp/wp-content/themes/phila.gov-theme/partials/content-feedback.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/content-feedback.php
@@ -11,7 +11,7 @@
         <?php
         $link_text = "How can we make it better?";
         if ( !is_home() && !is_404() && !is_tax() ) :
-          $current_cat = phila_util_get_current_cat_name();
+          $current_cat = phila_util_get_current_cat_slug();
           $dept = "?dept=" . $current_cat;
           $feedback = '<a href="/feedback/%1$s">%2$s</a>';
 

--- a/wp/wp-content/themes/phila.gov-theme/partials/content-feedback.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/content-feedback.php
@@ -10,7 +10,7 @@
       <p>We're still working on this page's design and content.
         <?php
         $link_text = "How can we make it better?";
-        if ( !is_home() && !is_404() && !is_tax() ) :
+        if ( !is_home() && !is_404() && !is_tax() && !is_archive() ) :
           $current_cat = phila_util_get_current_cat_slug();
           $dept = "?dept=" . $current_cat;
           $feedback = '<a href="/feedback/%1$s">%2$s</a>';


### PR DESCRIPTION
This PR applies the new function in the content-feedback partial solving problems with special characters in friendly names of categories (example: Mayor's Office vs. mayor)