### PR TITLE
Replace .alternate with .contrast

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/blogs.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/blogs.php
@@ -45,9 +45,9 @@ function latest_posts_shortcode($atts) {
     $post_counter = 0;
 
   if ( is_flag ('list', $atts) ) {
-    $output .= '<div class="large-24 columns"><h2 class="alternate">' . $a['name'] . '</h2><div class="news"><ul>';
+    $output .= '<div class="large-24 columns"><h2 class="contrast">' . $a['name'] . '</h2><div class="news"><ul>';
   }else{
-    $output .= '<div class="large-24 columns"><h2 class="alternate">' . $a['name'] . '</h2><div class="row">';
+    $output .= '<div class="large-24 columns"><h2 class="contrast">' . $a['name'] . '</h2><div class="row">';
   }
 
     while( $blog_loop->have_posts() ) : $blog_loop->the_post();

--- a/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/news.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/news.php
@@ -65,9 +65,9 @@ function recent_news_shortcode($atts) {
     $post_counter = 0;
 
   if ( is_flag ( 'list', $atts ) ) {
-      $output .= '<div class="large-24 columns"><h2 class="alternate">' . $a['name'] . '</h2><div class="news"><ul>';
+      $output .= '<div class="large-24 columns"><h2 class="contrast">' . $a['name'] . '</h2><div class="news"><ul>';
     }else{
-      $output .= '<div class="large-24 columns"><h2 class="alternate">' . $a['name'] . '</h2><div class="row">';
+      $output .= '<div class="large-24 columns"><h2 class="contrast">' . $a['name'] . '</h2><div class="row">';
     }
 
     while( $news_loop->have_posts() ) : $news_loop->the_post();

--- a/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/notices.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/notices.php
@@ -29,7 +29,7 @@ function notices_shortcode( $atts ) {
 
   if( $notices_loop->have_posts() ) {
 
-    $output .= '<h2 class="alternate">Notices</h2>';
+    $output .= '<h2 class="contrast">Notices</h2>';
     $output .= '<div class="notices content-block">';
 
     $output .= '<ul class="no-bullet pan">';
@@ -56,7 +56,7 @@ function notices_shortcode( $atts ) {
     }
 
   }else {
-    $output .= '<h2 class="alternate">Notices</h2>';
+    $output .= '<h2 class="contrast">Notices</h2>';
     $output .= '<div class="notices content-block">';
     $output .= '<p>There are no notices.</p>';
     $output .= '</div>';

--- a/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/press-releases.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/press-releases.php
@@ -33,7 +33,7 @@ function press_release_shortcode($atts) {
   if( $press_release_loop->have_posts() ) {
     $post_counter = 0;
 
-    $output .= '<div class="large-24 columns"><h2 class="alternate">' . __('Press Releases', 'phila-gov') . '</h2><ul class="no-bullet pan border-bottom-list">';
+    $output .= '<div class="large-24 columns"><h2 class="contrast">' . __('Press Releases', 'phila-gov') . '</h2><ul class="no-bullet pan border-bottom-list">';
 
     while( $press_release_loop->have_posts() ) :
       $press_release_loop->the_post();

--- a/wp/wp-content/themes/phila.gov-theme/templates/single-on-site-content.php
+++ b/wp/wp-content/themes/phila.gov-theme/templates/single-on-site-content.php
@@ -145,7 +145,7 @@
           </div>
         <?php elseif ( $row_one_col_one_type  == 'phila_module_row_1_col_1_custom_text' ): ?>
           <div class="large-18 columns">
-            <h2 class="alternate"><?php echo($row_one_col_one_text_title); ?></h2>
+            <h2 class="contrast"><?php echo($row_one_col_one_text_title); ?></h2>
             <div>
               <?php echo($row_one_col_one_textarea); ?>
             </div>
@@ -161,7 +161,7 @@
           </div>
         <?php elseif ( $row_one_col_two_type  == 'phila_module_row_1_col_2_custom_text' ): ?>
           <div class="large-6 columns">
-            <h2 class="alternate"><?php echo($row_one_col_two_text_title); ?></h2>
+            <h2 class="contrast"><?php echo($row_one_col_two_text_title); ?></h2>
             <div class="panel no-margin">
               <div>
                 <?php echo($row_one_col_two_textarea); ?>
@@ -201,7 +201,7 @@
   <?php if ( !empty( $row_two_full_col_cal_id ) ) : ?>
     <div class="row">
       <div class="columns">
-        <h2 class="alternate">Calendar</h2>
+        <h2>Calendar</h2>
       </div>
     </div>
 
@@ -224,7 +224,7 @@
      <div class="row">
        <?php if ( $row_two_col_one_type  == 'phila_module_row_2_col_1_calendar' ): ?>
          <div class="medium-12 columns">
-           <h2 class="alternate">Calendar</h2>
+           <h2 class="contrast">Calendar</h2>
            <div class="event-box">
              <?php echo do_shortcode('[calendar id="' . $row_two_col_one_cal_id .'"]'); ?>
            </div>
@@ -241,7 +241,7 @@
          <?php endif; ?>
          <?php if ( $row_two_col_two_type  == 'phila_module_row_2_col_2_calendar' ): ?>
            <div class="medium-12 columns">
-             <h2 class="alternate">Calendar</h2>
+             <h2 class="contrast">Calendar</h2>
              <div class="event-box">
                <?php echo do_shortcode('[calendar id="' . $row_two_col_two_cal_id .'"]'); ?>
              </div>


### PR DESCRIPTION
Replaces references to the `alternate` class with `contrast` across department single-on-site-content and shortcodes