### PR TITLE
Use array_shift instead of array_pop

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-filter-post-type-links.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-filter-post-type-links.php
@@ -34,7 +34,7 @@ class Phila_Gov_Filter_Post_Type_Links {
     if( is_wp_error( $terms ) || !$terms ) {
         $cat = 'uncategorised';
     } else {
-        $cat_obj = array_pop($terms);
+        $cat_obj = array_shift($terms);
         $cat = $cat_obj->slug;
     }
 
@@ -55,7 +55,7 @@ class Phila_Gov_Filter_Post_Type_Links {
     if( is_wp_error( $terms ) || !$terms ) {
       $cat = 'uncategorised';
     } else {
-      $cat_obj = array_pop($terms);
+      $cat_obj = array_shift($terms);
       $cat = $cat_obj->slug;
     }
 

--- a/wp/wp-content/plugins/phila.gov-customization/public/modify-post-type-links.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/modify-post-type-links.php
@@ -18,7 +18,7 @@ function phila_press_release_link( $post_link, $id = 0 ) {
     if( is_wp_error( $terms ) || !$terms ) {
         $cat = 'uncategorised';
     } else {
-        $cat_obj = array_pop($terms);
+        $cat_obj = array_shift($terms);
         $cat = $cat_obj->slug;
     }
 
@@ -47,7 +47,7 @@ function phila_news_link( $post_link, $id = 0 ) {
     if( is_wp_error( $terms ) || !$terms ) {
         $cat = 'uncategorised';
     } else {
-        $cat_obj = array_pop($terms);
+        $cat_obj = array_shift($terms);
         $cat = $cat_obj->slug;
     }
 


### PR DESCRIPTION
Changes behavior when multiple categories are added to an item. Instead of assigning the last chosen category, use the first alphabetically. 