### PR TITLE
Homepage toggler

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-admin-templates.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-admin-templates.php
@@ -45,6 +45,11 @@ class Phila_Gov_Admin_Templates {
           'one_page_department' => 'One Page Department',
           ),
        ),
+       array(
+      'desc'  => 'Is this a department homepage?',
+      'id'    => $prefix . 'department_home_page',
+      'type'  => 'checkbox',
+      ),
     ),
   );
    return $meta_boxes;

--- a/wp/wp-content/plugins/phila.gov-customization/admin/js/admin.js
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/js/admin.js
@@ -168,6 +168,7 @@ jQuery(document).ready(function($) {
     $('[id^=phila_action_panel_summary_multi_]').rules('add', {
       maxlength: 180
     });
+    $( '#phila_department_home_page' ).prop( 'checked', true );
   }
 
   if ( ( typenow == 'department_page' ) )  {
@@ -193,6 +194,7 @@ jQuery(document).ready(function($) {
         //remove the rules specific to one_page_department
         $('#phila_module_row_1_col_1_textarea').rules('remove', 'maxlength');
         $('[id^=phila_action_panel_summary_multi_]').rules('remove', 'maxlength');
+        $( '#phila_department_home_page' ).prop( 'checked', false );
       }
     });
   }


### PR DESCRIPTION
* Add metadata to department pages to define homepage status.
* Check if page uses the one-page department template and automatically assign homepage status.