### PR TITLE
Set a fastcgi_cache_path max_size

### DIFF
--- a/nginx/conf.d/fastcgi_cache.conf
+++ b/nginx/conf.d/fastcgi_cache.conf
@@ -1,4 +1,4 @@
-fastcgi_cache_path /var/run/nginx-cache levels=1:2 keys_zone=WORDPRESS:10m inactive=60m;
+fastcgi_cache_path /var/run/nginx-cache levels=1:2 keys_zone=WORDPRESS:10m inactive=60m max_size=90M;
 fastcgi_cache_key "$request_method$request_uri";
 fastcgi_cache_use_stale error timeout invalid_header http_500;
 fastcgi_ignore_headers Cache-Control Expires Set-Cookie;

--- a/nginx/conf.d/fastcgi_cache.conf
+++ b/nginx/conf.d/fastcgi_cache.conf
@@ -1,4 +1,4 @@
-fastcgi_cache_path /var/run/nginx-cache levels=1:2 keys_zone=WORDPRESS:10m inactive=60m max_size=90M;
+fastcgi_cache_path /var/run/nginx-cache levels=1:2 keys_zone=WORDPRESS:10m inactive=60m max_size=90m;
 fastcgi_cache_key "$request_method$request_uri";
 fastcgi_cache_use_stale error timeout invalid_header http_500;
 fastcgi_ignore_headers Cache-Control Expires Set-Cookie;


### PR DESCRIPTION
Set a `max_size=90m` to alleviate errors related to the fastcgi cache filling up.

We may want to change the cache dir from `/var/run/nginx-cache` to `/var/cache/nginx/fastcgi_temp/`, but for now this should keep us from hitting 100m with room to spare.

Thanks @gsf for the advice