### PR TITLE
Alerts

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-site-wide-alert.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-site-wide-alert.php
@@ -74,11 +74,11 @@ class Phila_Gov_Site_Wide_Alert {
           'visible' => array('phila_type', '=', 'Other'),
         ),
         array(
-          'name'  => 'Custom Alert Class',
+          'name'  => 'Non-Urgent Alert',
           'id'    => $prefix . 'alert-class',
           'type'  => 'checkbox',
           'class' => 'other-alert-class',
-          'desc'  => 'Non-urgent alert',
+          'desc'  => 'Use the "subtle" class',
           'visible' => array('phila_type', '=', 'Other'),
         ),
         array(

--- a/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-site-wide-alert.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-site-wide-alert.php
@@ -61,7 +61,8 @@ class Phila_Gov_Site_Wide_Alert {
           'type'  => 'text',
           'class' => 'type-other',
           'size'  => 25,
-          'desc'  => 'E.g. <i>Hurricane Warning</i>'
+          'desc'  => 'E.g. <i>Hurricane Warning</i>',
+          'visible' => array('phila_type', '=', 'Other'),
         ),
         array(
           'name'  => 'Custom Alert Icon',
@@ -69,15 +70,20 @@ class Phila_Gov_Site_Wide_Alert {
           'type'  => 'text',
           'class' => 'other-icon',
           'size'  => 25,
-          'desc'  => '<a href="http://ionicons.com/" target="_new">Choose icon</a>. Enter icon name only i.e. <i>ion-alert-circled</i>'
+          'desc'  => '<a href="http://ionicons.com/" target="_new">Choose icon</a>. Enter icon name only i.e. <i>ion-alert-circled</i>',
+          'visible' => array('phila_type', '=', 'Other'),
         ),
         array(
           'name'  => 'Custom Alert Class',
           'id'    => $prefix . 'alert-class',
-          'type'  => 'text',
+          'type'  => 'checkbox',
           'class' => 'other-alert-class',
-          'size'  => 25,
-          'desc'  => 'For non-urgent alerts use the "subtle" class.'
+          'desc'  => 'Non-urgent alert',
+          'visible' => array('phila_type', '=', 'Other'),
+        ),
+        array(
+          'type' => 'divider',
+          'visible' => array('phila_type', '=', 'Other'),
         ),
         array(
           'name'  => 'Alert Start Time',

--- a/wp/wp-content/plugins/phila.gov-customization/admin/js/alerts.js
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/js/alerts.js
@@ -3,23 +3,6 @@
 *
 */
 jQuery(document).ready(function($) {
-  /*show/hide metaboxes if alert type is "other" */
-  // $('.other-icon').hide();
-  // $('.type-other').hide();
-  //
-  // $('#phila_type').change(function(){
-  //   if($('#phila_type').val() == 'Other') {
-  //     $('.other-icon').show();
-  //     $('.type-other').show();
-  //   } else {
-  //     $('.other-icon').hide();
-  //     $('.type-other').hide();
-  //   }
-  // });
-  // if($('#phila_type').val() == 'Other') {
-  //   $('.other-icon').show();
-  //   $('.type-other').show();
-  // }
   $("#post").validate({
     rules: {
        'post_title' : 'required'

--- a/wp/wp-content/plugins/phila.gov-customization/admin/js/alerts.js
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/js/alerts.js
@@ -4,22 +4,22 @@
 */
 jQuery(document).ready(function($) {
   /*show/hide metaboxes if alert type is "other" */
-  $('.other-icon').hide();
-  $('.type-other').hide();
-
-  $('#phila_type').change(function(){
-    if($('#phila_type').val() == 'Other') {
-      $('.other-icon').show();
-      $('.type-other').show();
-    } else {
-      $('.other-icon').hide();
-      $('.type-other').hide();
-    }
-  });
-  if($('#phila_type').val() == 'Other') {
-    $('.other-icon').show();
-    $('.type-other').show();
-  }
+  // $('.other-icon').hide();
+  // $('.type-other').hide();
+  //
+  // $('#phila_type').change(function(){
+  //   if($('#phila_type').val() == 'Other') {
+  //     $('.other-icon').show();
+  //     $('.type-other').show();
+  //   } else {
+  //     $('.other-icon').hide();
+  //     $('.type-other').hide();
+  //   }
+  // });
+  // if($('#phila_type').val() == 'Other') {
+  //   $('.other-icon').show();
+  //   $('.type-other').show();
+  // }
   $("#post").validate({
     rules: {
        'post_title' : 'required'

--- a/wp/wp-content/plugins/phila.gov-customization/public/class-phila-gov-site-wide-alert-rendering.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/class-phila-gov-site-wide-alert-rendering.php
@@ -62,6 +62,7 @@ class Phila_Gov_Site_Wide_Alert_Rendering {
             $alert_icon = 'ion-ios-rainy';
             break;
           case 'Other':
+            $alert_type_other = rwmb_meta( 'phila_type-other', $args = array('type' => 'text'));
             $alert_class = rwmb_meta( 'phila_alert-class', $args = array('type' => 'text'));
             $alert_icon = rwmb_meta( 'phila_icon', $args = array('type' => 'text'));
             ($alert_icon == '') ? $alert_icon = 'ion-alert-circled' : $alert_icon;
@@ -77,7 +78,7 @@ class Phila_Gov_Site_Wide_Alert_Rendering {
 
         if ( ( $alert_start <= $now && $alert_end >= $now ) || ( is_preview() && is_singular( 'site_wide_alert' ) ) ) :
 
-        ?><div id="site-wide-alert" <?php if ($alert_class != '') echo 'class="'. $alert_class .'"'; ?> data-swiftype-index='false'>
+        ?><div id="site-wide-alert" <?php if ( $alert_type == 'Other' && $alert_class ) echo 'class="subtle"'; ?> data-swiftype-index='false'>
             <div class="row"><?php
         echo '<div class="large-9 columns">';
         echo '<h2><i class="ionicons ' . $alert_icon . '"></i>' . get_the_title() .'</h2>';
@@ -91,8 +92,11 @@ class Phila_Gov_Site_Wide_Alert_Rendering {
         echo '</div>';
         echo '</div>';
         echo '<div class="large-15 columns">';
+
         if ($alert_type != 'Other'){
           echo '<strong>'.$alert_type . ': </strong>';
+        } elseif ( $alert_type == 'Other' && isset( $alert_type_other ) && $alert_type_other != '' ){
+          echo '<strong>' . $alert_type_other . ': </strong>';
         }
 
         $content = get_the_content();


### PR DESCRIPTION
- Use MetaBox.io's Conditional Logic extension to hide/show "Other" options
- Remove hide/show logic from `alerts.js`
- If alert type is "Other"
 - Use the Custom Alert Type content if set
 - Append `.subtle` to alert if non-urgent alert is true

**Any existing Site-Wide Alerts will need to be updated after merging**