### PR TITLE
General Cleanup

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes.php
@@ -1105,6 +1105,11 @@ $meta_var_custom_feature = array(
     'type' => 'textarea',
   ),
   array(
+    'name' => 'Feature URL Text',
+    'id' => $prefix . 'feature_url_text',
+    'type' => 'text',
+  ),
+  array(
     'name' => 'URL',
     'id' => $prefix . 'feature_url',
     'type' => 'url',

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-call-to-action-multi.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-call-to-action-multi.php
@@ -23,7 +23,7 @@
   if ( ! empty( $action_panel_section ) ) : ?>
   <?php $item_count = count($action_panel_multi); ?>
   <?php $columns = phila_grid_column_counter( $item_count ); ?>
-
+    <!-- Display Multi Call to Action as Resource List -->
     <section class="row <?php if( $item_count > 1 ) echo 'equal-height';?>">
       <div class="columns">
         <h2 class="contrast"><?php echo $action_panel_title; ?></h2>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-custom-text-multi.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-custom-text-multi.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ *
+ * Partial for rendering Cloneable Custom Textareas
+ *
+ */
+
+?>
+<?php
+if ( !empty( $custom_text )):
+$custom_text_title = $custom_text['phila_custom_row_title'];
+$custom_text_group = $custom_text['phila_custom_text_group'];
+?>
+<div class="large-18 columns custom-text-multi">
+<h2 class="contrast"><?php echo($custom_text['phila_custom_row_title']); ?></h2>
+<?php if ( is_array( $custom_text_group ) ):?>
+<?php $item_count = count($custom_text_group); ?>
+<?php $columns = phila_grid_column_counter( $item_count ); ?>
+<div class="row <?php if( $item_count > 1 ) echo 'equal-height';?> ">
+  <?php foreach ($custom_text_group as $key => $value):?>
+    <div class="medium-<?php echo $columns ?> columns <?php if( $item_count > 1 ) echo 'equal';?>">
+
+      <?php if ( isset( $custom_text_group[$key]['phila_custom_text_title'] ) && $custom_text_group[$key]['phila_custom_text_title'] != '') : ?>
+        <h3><?php echo $custom_text_group[$key]['phila_custom_text_title']; ?></h3>
+      <?php endif;?>
+
+      <?php if ( isset( $custom_text_group[$key]['phila_custom_text_content'] ) && $custom_text_group[$key]['phila_custom_text_content'] != '') : ?>
+        <p><?php echo $custom_text_group[$key]['phila_custom_text_content']; ?></p>
+      <?php else :?>
+        <div class="placeholder">
+          Please enter content.
+        </div>
+      <?php endif;?>
+
+    </div>
+  <?php endforeach; ?>
+</div>
+<?php endif; ?>
+</div>
+<?php endif; ?>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-custom-text.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-custom-text.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ *
+ * Partial for rendering Custom Textareas
+ *
+ */
+?>
+<?php if ( !empty( $custom_text )):
+  $custom_text_title = $custom_text['phila_custom_text_title'];
+  $custom_text_content = $custom_text['phila_custom_text_content'];
+?>
+  <?php if ( !empty( $custom_text_title ) ) :?>
+    <h2 class="contrast"><?php echo( $custom_text_title ); ?></h2>
+  <?php endif; ?>
+  <?php if ( !empty( $custom_text_content ) ) :?>
+    <div>
+      <?php echo( $custom_text_content ); ?>
+    </div>
+  <?php else :?>
+    <div class="placeholder">
+      Please enter content.
+    </div>
+  <?php endif; ?>
+<?php endif; ?>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-department-homepage.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-department-homepage.php
@@ -30,7 +30,7 @@
 
               <?php if ( !empty( $cal_id ) ):?>
                 <!-- Full Width Calendar -->
-                <section class="row expanded">
+                <section class="expanded">
                   <div class="row">
                     <div class="columns">
                       <h2>Events</h2>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-department-homepage.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-department-homepage.php
@@ -25,12 +25,11 @@
                 </section>
 
             <?php elseif ( $current_row_option == 'phila_full_width_calendar'):
-              //TODO: verify that these vars exist before setting... offload to function?
               $cal_id = isset( $current_row['phila_full_options']['phila_full_width_calendar']['phila_full_width_calendar_id'] ) ? $current_row['phila_full_options']['phila_full_width_calendar']['phila_full_width_calendar_id'] : '' ;
               $cal_url = isset( $current_row['phila_full_options']['phila_full_width_calendar']['phila_full_width_calendar_url'] ) ? $current_row['phila_full_options']['phila_full_width_calendar']['phila_full_width_calendar_url'] : '';?>
 
-              <!-- Full Width Calendar -->
               <?php if ( !empty( $cal_id ) ):?>
+                <!-- Full Width Calendar -->
                 <section class="row expanded">
                   <div class="row">
                     <div class="columns">

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-department-homepage.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-department-homepage.php
@@ -15,7 +15,8 @@
       foreach ($page_rows as $key => $value):
         $current_row = $page_rows[$key];?>
         <!-- Grid Row -->
-        <?php if ( $current_row['phila_grid_options'] == 'phila_grid_options_full'):
+        <?php if ( ( isset( $current_row['phila_grid_options'] ) && $current_row['phila_grid_options'] == 'phila_grid_options_full' ) &&  isset( $current_row['phila_full_options']['phila_full_options_select'] ) ):
+
             $current_row_option = $current_row['phila_full_options']['phila_full_options_select'];
 
             if ( $current_row_option == 'phila_blog_posts'): ?>
@@ -87,7 +88,8 @@
               <?php endif; ?>
 
           <?php endif; ?>
-        <?php elseif ($current_row['phila_grid_options'] == 'phila_grid_options_thirds'):
+        <?php elseif ( ( isset( $current_row['phila_grid_options'] ) && $current_row['phila_grid_options'] == 'phila_grid_options_thirds') && ( isset( $current_row['phila_two_thirds_options'] ['phila_two_thirds_col'] ) && isset( $current_row['phila_two_thirds_options'] ['phila_one_third_col'] ) ) ):
+          
           $current_row_option_one = $current_row['phila_two_thirds_options'] ['phila_two_thirds_col'];
           $current_row_option_two = $current_row['phila_two_thirds_options'] ['phila_one_third_col']; ?>
 

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-department-homepage.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-department-homepage.php
@@ -51,49 +51,17 @@
                 </section>
               <?php endif;?>
             <?php elseif ($current_row_option == 'phila_feature_p_i'): ?>
-              <!-- Display Featured Programs and Initiatives -->
-              <section class="mvl">
-                <div class="row">
-                  <div class="columns">
-                    <h2 class="contrast"> Core Initiatives </h2>
-                  </div>
-                </div>
-                <section class="row equal-height mbl">
-                  <?php
-                    $featured = $current_row['phila_full_options']['phila_feature_p_i']['phila_p_i']['phila_p_i_items'];
-                    foreach ($featured as $key => $value):
-                  ?>
-                    <article class="large-8 medium-24 columns featured-content programs equal">
-                      <?php
-                      //FIXME: This needs to be reworked a bit...
-                        if ( null !== rwmb_meta( 'phila_p_i_images', $arg ='type=textarea', $post_id = intval($featured[$key]) )):
-                          $featured_post = get_post( $featured[$key] );
-                          $featured_item =  rwmb_meta( 'phila_p_i_images', $arg ='type=textarea', $post_id = intval($featured[$key]) );
-                          $featured_image = isset( $featured_item['phila_p_i_featured'] ) ? $featured_item['phila_p_i_featured'] : '';
-                          $short_description = isset( $featured_item['phila_short_feat_desc'] ) ? $featured_item['phila_short_feat_desc'] : '';
-                          $long_description = isset( $featured_item['phila_long_feat_desc'] ) ? $featured_item['phila_long_feat_desc'] : '';
-                        endif;
-                      ?>
-                        <div class="featured-thumbnail">
-                          <img src="<?php echo $featured_image;?>" alt="" class="mrm">
-                        </div>
-                        <div>
-                          <header>
-                            <a href="<?php echo get_permalink($featured[$key]); ?>"><h4 class="h6"><?php echo $featured_post->post_title; ?></h4></a>
-                          </header>
-                          <p><?php echo $short_description;?></p>
-                        </div>
-                      </article>
-                  <?php endforeach;?>
-                </section>
-              </section>
-            <?php elseif ($current_row_option == 'phila_get_involved'): ?>
-              <!-- Display Multi Call to Action as Get Involved -->
               <?php
-                $phila_dept_homepage_cta = $current_row['phila_full_options']['phila_call_to_action_multi']['phila_call_to_action_section'];
-                include(locate_template('partials/departments/content-get-involved.php'));
+                $featured = $current_row['phila_full_options']['phila_feature_p_i']['phila_p_i']['phila_p_i_items'];
+                if ( !empty( $featured ) ):
+                  include(locate_template('partials/departments/content-featured-pages.php'));
+                endif;
               ?>
-
+            <?php elseif ($current_row_option == 'phila_get_involved'): ?>
+              <?php if ( !isset( $current_row['phila_full_options']['phila_call_to_action_multi']['phila_call_to_action_section'] ) ):
+                $phila_dept_homepage_cta = $current_row['phila_full_options']['phila_call_to_action_multi']['phila_call_to_action_section'];
+                  include(locate_template('partials/departments/content-get-involved.php'));
+                endif; ?>
             <?php elseif ( $current_row_option == 'phila_full_width_press_releases'): ?>
               <!-- Press Releases -->
                 <section class="row mvl">
@@ -102,33 +70,29 @@
 
             <?php elseif ($current_row_option == 'phila_resource_list'): ?>
               <!-- Display Multi Call to Action as Resource List -->
-              <?php
+              <?php if ( isset( $current_row['phila_full_options']['phila_call_to_action_multi']['phila_call_to_action_section'] ) ):
                 $phila_dept_homepage_cta = $current_row['phila_full_options']['phila_call_to_action_multi']['phila_call_to_action_section'];
                 include(locate_template('partials/departments/content-call-to-action-multi.php'));
-              ?>
+              endif; ?>
 
             <?php elseif ( $current_row_option == 'phila_custom_text'): ?>
-
-              <?php $custom_text = $current_row['phila_full_options']['phila_custom_text']; ?>
-                <section class="row mvl">
-                  <div class="large-24 columns">
-                    <h2 class="contrast"><?php echo($custom_text['phila_custom_text_title']); ?></h2>
-                    <div>
-                      <?php echo($custom_text['phila_custom_text_content']); ?>
+              <?php if ( isset( $current_row['phila_full_options']['phila_custom_text'] ) ):
+                  $custom_text = $current_row['phila_full_options']['phila_custom_text']; ?>
+                  <!-- Display Custom Textarea -->
+                  <section class="row mvl">
+                    <div class="large-24 columns">
+                      <?php include(locate_template('partials/departments/content-custom-text.php'));?>
                     </div>
-                    <?php if ( $custom_text == '' ) :?>
-                      <div class="placeholder">
-                        Please enter content.
-                      </div>
-                    <?php endif; ?>
-                  </div>
-                </section>
+                  </section>
+              <?php endif; ?>
+
           <?php endif; ?>
         <?php elseif ($current_row['phila_grid_options'] == 'phila_grid_options_thirds'):
           $current_row_option_one = $current_row['phila_two_thirds_options'] ['phila_two_thirds_col'];
           $current_row_option_two = $current_row['phila_two_thirds_options'] ['phila_one_third_col']; ?>
 
           <section class="row mvl">
+
           <?php if ( $current_row_option_one['phila_two_thirds_col_option'] == 'phila_blog_posts'): ?>
             <!-- Blog Content -->
             <div class="large-18 columns">
@@ -136,34 +100,25 @@
                 <?php echo do_shortcode('[recent-posts posts="3"]'); ?>
               </div>
             </div>
+
           <?php elseif ( $current_row_option_one['phila_two_thirds_col_option'] == 'phila_custom_text'):?>
-
-            <?php $custom_text = $current_row_option_one['phila_custom_text']; ?>
-
+            <?php if ( isset( $current_row_option_one['phila_custom_text'] ) ):
+              $custom_text = $current_row_option_one['phila_custom_text']; ?>
               <div class="large-18 columns">
-                <h2 class="contrast"><?php echo($custom_text['phila_custom_text_title']); ?></h2>
-                <div>
-                  <?php echo($custom_text['phila_custom_text_content']); ?>
-                </div>
-                <?php if ( $custom_text == '' ) :?>
-                  <div class="placeholder">
-                    Please enter content.
-                  </div>
-                <?php endif; ?>
+                <?php include(locate_template('partials/departments/content-custom-text.php'));?>
               </div>
-
             <?php endif;?>
 
-            <?php if ( $current_row_option_two['phila_one_third_col_option'] == 'phila_connect_panel'):
-              $connect_panel = $current_row_option_two['phila_connect_panel'];
+          <?php endif;?>
 
-              // Set Connect Panel vars
-              $connect_vars = phila_connect_panel($connect_panel);
-              // TODO: get_template_part vs. include: can't pass arbitrary vars to templates
-              // get_template_part( 'partials/departments/content', 'connect' );
-              include(locate_template('partials/departments/content-connect.php'));
+            <?php if ( $current_row_option_two['phila_one_third_col_option'] == 'phila_connect_panel'):?>
+              <?php if ( isset( $current_row_option_two['phila_connect_panel'] ) ):
+                $connect_panel = $current_row_option_two['phila_connect_panel'];
+                $connect_vars = phila_connect_panel($connect_panel);
+                include(locate_template('partials/departments/content-connect.php'));
+              endif; ?>
 
-            endif; ?>
+            <?php endif; ?>
           </section>
         <?php endif; ?>
       <!-- Grid Row -->

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-featured-pages.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-featured-pages.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ *
+ * Partial for rendering Featured Programs and Initiatives
+ *
+ */
+?>
+<!-- Display Featured Programs and Initiatives -->
+<section class="mvl">
+  <div class="row">
+    <div class="columns">
+      <h2 class="contrast"> Core Initiatives </h2>
+    </div>
+  </div>
+  <section class="row equal-height mbl">
+    <?php
+      //FIXME: Need to count featured pages and set appropriate column widths
+      foreach ($featured as $key => $value):
+    ?>
+      <article class="large-8 medium-24 columns featured-content programs equal">
+        <?php
+          if ( null !== rwmb_meta( 'phila_p_i_images', $arg ='type=textarea', $post_id = intval($featured[$key]) )):
+            $featured_post = get_post( $featured[$key] );
+            $featured_item =  rwmb_meta( 'phila_p_i_images', $arg ='type=textarea', $post_id = intval($featured[$key]) );
+            $featured_image = isset( $featured_item['phila_p_i_featured'] ) ? $featured_item['phila_p_i_featured'] : '';
+            $short_description = isset( $featured_item['phila_short_feat_desc'] ) ? $featured_item['phila_short_feat_desc'] : '';
+            $long_description = isset( $featured_item['phila_long_feat_desc'] ) ? $featured_item['phila_long_feat_desc'] : '';
+          endif;
+        ?>
+          <div class="featured-thumbnail">
+            <img src="<?php echo $featured_image;?>" alt="" class="mrm">
+          </div>
+          <div>
+            <header>
+              <a href="<?php echo get_permalink($featured[$key]); ?>"><h4 class="h6"><?php echo $featured_post->post_title; ?></h4></a>
+            </header>
+            <p><?php echo $short_description;?></p>
+          </div>
+        </article>
+    <?php endforeach;?>
+  </section>
+</section>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-get-involved.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-get-involved.php
@@ -7,7 +7,7 @@
 
 ?>
 <?php
-  if( isset($phila_dept_homepage_cta)):
+  if( isset($phila_dept_homepage_cta ) ):
     $action_panel_section = $phila_dept_homepage_cta;
   else :
     $action_panel_section = rwmb_meta('phila_call_to_action_section');
@@ -19,7 +19,7 @@
   $action_panel_bg = isset( $action_panel_section['phila_bg_image'] ) ? $action_panel_section['phila_bg_image'] : '';
 
 
-  if ( ! empty( $action_panel_section ) ) : ?>
+  if ( !empty( $action_panel_section ) ) : ?>
   <?php $item_count = count($action_panel_multi); ?>
   <?php $columns = phila_grid_column_counter( $item_count ); ?>
   <section class="mvl">
@@ -51,7 +51,7 @@
         ?>
         <?php phila_grid_column_counter( $item_count ); ?>
         <div class="medium-<?php echo $columns; ?> columns">
-          <?php if (!$action_panel_link == ''): ?>
+          <?php if ( !empty( $action_panel_link ) ): ?>
           <a href="<?php echo $action_panel_link; ?>"  class="action-panel">
             <div class="panel <?php if( $item_count > 1 ) echo 'equal';?>">
             <header class="<?php echo $columns == '24' ? 'text-align-left' : ''; ?>">
@@ -67,7 +67,7 @@
                <span><i class="fa <?php echo $action_panel_fa; ?> fa-4x" aria-hidden="true"></i></span>
              </div>
             <?php endif; ?>
-            <?php if (!$action_panel_cta_text == ''): ?>
+            <?php if ( !empty( $action_panel_cta_text ) ): ?>
               <span class="<?php if ($action_panel_link_loc) echo 'external';?>"><?php echo $action_panel_cta_text; ?></span>
             <?php endif; ?>
             </header>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-get-involved.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-get-involved.php
@@ -22,6 +22,7 @@
   if ( !empty( $action_panel_section ) ) : ?>
   <?php $item_count = count($action_panel_multi); ?>
   <?php $columns = phila_grid_column_counter( $item_count ); ?>
+  <!-- Display Multi Call to Action as Get Involved -->
   <section class="mvl">
     <div class="row">
       <div class="columns">

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-hero-header.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-hero-header.php
@@ -23,28 +23,28 @@
   $hero_header_call_to_action_button_text = rwmb_meta( 'phila_hero_header_call_to_action_button_text', $args = array('type' => 'text'));
 ?>
 
-<?php if ( $hero_header_title == '' && ( !$hero_header_title_l1 == '' || !$hero_header_title_l2 == '' ) ): ?>
+<?php if ( empty( $hero_header_title ) && ( !empty( $hero_header_title_l1 ) || !empty( $hero_header_title_l2 ) ) ): ?>
 <div class="hero-measureline" data-type="hero-measure"><?php echo $hero_header_title_l1; ?></div>
 <div class="hero-measureline emphasis" data-type="hero-measure-emphasis"><?php echo $hero_header_title_l2; ?></div>
 <?php endif;?>
 
-<?php if (!$hero_header_image == ''): ?>
+<?php if ( !empty( $hero_header_image ) ): ?>
 <!-- Hero-Header MetaBox Modules -->
 <div class="row mtm">
   <div class="small-24 columns">
     <section class="hero-header">
       <img id="header-image" class="size-full wp-image-4069" src="<?php echo $hero_header_image; ?>" alt="<?php echo $hero_header_alt_text;?>" width="975" height="431" />
-      <?php if (!$hero_header_credit == ''): ?>
+      <?php if ( !$hero_header_credit == '' ): ?>
         <div class="photo-credit small-text">
           <span><i class="fa fa-camera" aria-hidden="true"></i> Photo by <?php echo $hero_header_credit; ?></span>
         </div>
       <?php endif; ?>
-    <?php if (!$hero_header_title == '' || !$hero_header_title_l1 == '' || !$hero_header_title_l2 == '' ): ?>
+    <?php if ( !empty( $hero_header_title ) || !empty( $hero_header_title_l1 ) || !empty( $hero_header_title_l2 ) ): ?>
       <div class="intro row">
         <div class="column">
 
           <h1>
-            <?php if (!$hero_header_title == ''):
+            <?php if ( !empty( $hero_header_title ) ):
                     echo $hero_header_title;
                   else:?>
                     <span class="hero-tagline" data-type="hero-tagline">
@@ -55,10 +55,10 @@
                     </span>
             <?php endif;?>
           </h1>
-          <?php if (!$hero_header_body_copy == ''): ?>
+          <?php if ( !empty( $hero_header_body_copy ) ): ?>
             <p><?php echo $hero_header_body_copy; ?></p>
           <?php endif; ?>
-          <?php if (!$hero_header_call_to_action_button_url == ''): ?>
+          <?php if ( !empty( $hero_header_call_to_action_button_url ) ): ?>
             <p><a href="<?php echo $hero_header_call_to_action_button_url; ?>" class="button alternate no-margin"><?php echo $hero_header_call_to_action_button_text; ?></a></p>
           <?php endif; ?>
         </div>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-list-items.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-list-items.php
@@ -9,15 +9,17 @@
 $row_title = isset( $list_items['phila_row_title'] ) ? $list_items['phila_row_title'] : '';
 $summary = isset( $list_items['phila_summary'] ) ? $list_items['phila_summary'] : '';
 $list_item_group = isset( $list_items['phila_list'] ) ? $list_items['phila_list'] : '' ;
-?>
 
+if ( !empty( $list_item_group ) ): ?>
 <section class="row mvl">
   <div class="large-24 columns">
-    <h2 class="contrast"><?php echo( $row_title ); ?></h2>
+    <?php if ( !empty( $row_title ) ): ?>
+      <h2 class="contrast"><?php echo( $row_title ); ?></h2>
+    <?php endif; ?>
       <div class="row">
         <div class="large-6 columns">
           <?php
-            if ($summary != ''):
+            if ( !empty( $summary ) ):
               echo( $summary );
             else :
               echo '<div class="placeholder">Please enter a summary.</div>';
@@ -58,3 +60,4 @@ $list_item_group = isset( $list_items['phila_list'] ) ? $list_items['phila_list'
       </div>
   </div>
 </section>
+<?php endif; ?>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
@@ -151,19 +151,25 @@
             <?php endif; ?>
 
             <?php if ( $current_row_option_two['phila_half_col_2_option'] == 'phila_custom_text'):?>
-              <?php $custom_text = $current_row_option_one['phila_custom_text']; ?>
 
-                <div class="large-12 columns">
-                  <h2 class="contrast"><?php echo($custom_text['phila_custom_text_title']); ?></h2>
-                  <div>
-                    <?php echo($custom_text['phila_custom_text_content']); ?>
-                  </div>
-                  <?php if ( $custom_text == '' ) :?>
-                    <div class="placeholder">
-                      Please enter content.
+                <?php if ( isset( $current_row_option_two['phila_custom_text'] ) ):
+                  $custom_text = $current_row_option_two['phila_custom_text']; ?>
+                    <div class="large-12 columns">
+                      <?php if ( !empty( $custom_text['phila_custom_text_title'] ) ) :?>
+                        <h2 class="contrast"><?php echo($custom_text['phila_custom_text_title']); ?></h2>
+                      <?php endif; ?>
+                      <?php if ( !empty( $custom_text['phila_custom_text_content'] ) ) :?>
+                        <div>
+                          <?php echo($custom_text['phila_custom_text_content']); ?>
+                        </div>
+                      <?php else :?>
+                        <div class="placeholder">
+                          Please enter content.
+                        </div>
+                      <?php endif; ?>
                     </div>
-                  <?php endif; ?>
-                </div>
+                <?php endif; ?>
+
             <?php elseif ( $current_row_option_two['phila_half_col_2_option'] == 'phila_pullquote'):?>
               <?php $pullquote = $current_row_option_two['phila_pullquote'];?>
               <div class="large-12 columns">

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
@@ -68,7 +68,6 @@
             <?php endif;?>
 
           <?php elseif ($current_row_option == 'phila_get_involved'): ?>
-            <!-- Display Multi Call to Action as Get Involved -->
             <?php if ( isset( $current_row['phila_full_options']['phila_call_to_action_multi']['phila_call_to_action_section'] ) ):
               $phila_dept_homepage_cta = $current_row['phila_full_options']['phila_call_to_action_multi']['phila_call_to_action_section'];
                 include(locate_template('partials/departments/content-get-involved.php'));

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
@@ -223,37 +223,12 @@
 
             <?php elseif ( $current_row_option_one['phila_two_thirds_col_option'] == 'phila_custom_text_multi'):?>
               <?php
-              // TODO: Move this block to partials/content-custom-text-multi.php
-                $custom_text = $current_row_option_one['phila_custom_text_multi'];
-                $custom_text_title = $custom_text['phila_custom_row_title'];
-                $custom_text_group = $custom_text['phila_custom_text_group'];
+                $custom_text = isset ( $current_row_option_one['phila_custom_text_multi'] ) ? $current_row_option_one['phila_custom_text_multi'] : '';
+                if ( !empty($custom_text) ):
+                  include(locate_template('partials/departments/content-custom-text-multi.php'));
+                endif;
               ?>
-              <div class="large-18 columns custom-text-multi">
-                <h2 class="contrast"><?php echo($custom_text['phila_custom_row_title']); ?></h2>
-              <?php if ( is_array( $custom_text_group ) ):?>
-                <?php $item_count = count($custom_text_group); ?>
-                <?php $columns = phila_grid_column_counter( $item_count ); ?>
-                <div class="row <?php if( $item_count > 1 ) echo 'equal-height';?> ">
-                  <?php foreach ($custom_text_group as $key => $value):?>
-                    <div class="medium-<?php echo $columns ?> columns <?php if( $item_count > 1 ) echo 'equal';?>">
 
-                      <?php if ( isset( $custom_text_group[$key]['phila_custom_text_title'] ) && $custom_text_group[$key]['phila_custom_text_title'] != '') : ?>
-                        <h3><?php echo $custom_text_group[$key]['phila_custom_text_title']; ?></h3>
-                      <?php endif;?>
-
-                      <?php if ( isset( $custom_text_group[$key]['phila_custom_text_content'] ) && $custom_text_group[$key]['phila_custom_text_content'] != '') : ?>
-                        <p><?php echo $custom_text_group[$key]['phila_custom_text_content']; ?></p>
-                      <?php else :?>
-                        <div class="placeholder">
-                          Please enter content.
-                        </div>
-                      <?php endif;?>
-
-                    </div>
-                  <?php endforeach; ?>
-                </div>
-              <?php endif; ?>
-            </div>
             <?php endif;?>
 
               <?php

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
@@ -86,9 +86,10 @@
             endif; ?>
 
           <?php elseif ( $current_row_option == 'phila_custom_text'): ?>
-            <!-- Display Custom Text -->
             <?php if ( isset( $current_row['phila_full_options']['phila_custom_text'] ) ):
-              $custom_text = $current_row['phila_full_options']['phila_custom_text'];?>              <section class="row mvl">
+              $custom_text = $current_row['phila_full_options']['phila_custom_text'];?>
+              <!-- Display Custom Text -->
+              <section class="row mvl">
                 <div class="large-24 column">
                   <?php if ( !empty( $custom_text['phila_custom_text_title'] ) ) :?>
                     <h2 class="contrast"><?php echo($custom_text['phila_custom_text_title']); ?></h2>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
@@ -201,20 +201,26 @@
                 </div>
               </div>
             <?php elseif ( $current_row_option_one['phila_two_thirds_col_option'] == 'phila_custom_text'):?>
-              <!-- Custom Text -->
-              <?php $custom_text = $current_row_option_one['phila_custom_text']; ?>
 
-                <div class="large-18 columns">
-                  <h2 class="contrast"><?php echo($custom_text['phila_custom_text_title']); ?></h2>
-                  <div>
-                    <?php echo($custom_text['phila_custom_text_content']); ?>
-                  </div>
-                  <?php if ( $custom_text == '' ) :?>
-                    <div class="placeholder">
-                      Please enter content.
+                <?php if ( isset( $current_row_option_one['phila_custom_text'] ) ):
+                  $custom_text = $current_row_option_one['phila_custom_text']; ?>
+                  <!-- Custom Text -->
+                    <div class="large-18 columns">
+                      <?php if ( !empty( $custom_text['phila_custom_text_title'] ) ) :?>
+                        <h2 class="contrast"><?php echo($custom_text['phila_custom_text_title']); ?></h2>
+                      <?php endif; ?>
+                      <?php if ( !empty( $custom_text['phila_custom_text_content'] ) ) :?>
+                        <div>
+                          <?php echo($custom_text['phila_custom_text_content']); ?>
+                        </div>
+                      <?php else :?>
+                        <div class="placeholder">
+                          Please enter content.
+                        </div>
+                      <?php endif; ?>
                     </div>
-                  <?php endif; ?>
-                </div>
+                <?php endif; ?>
+
             <?php elseif ( $current_row_option_one['phila_two_thirds_col_option'] == 'phila_custom_text_multi'):?>
               <?php
               // TODO: Move this block to partials/content-custom-text-multi.php

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
@@ -245,6 +245,7 @@
                   $feature_image = isset( $feature_panel['phila_feature_image'] ) ? $feature_panel['phila_feature_image'] : '';
                   $feature_text = isset( $feature_panel['phila_feature_text'] ) ? $feature_panel['phila_feature_text'] : '';
                   $feature_url = isset( $feature_panel['phila_feature_url'] ) ? $feature_panel['phila_feature_url'] : '';
+                  $feature_url_text = isset( $feature_panel['phila_feature_url_text'] ) ? $feature_panel['phila_feature_url_text'] : '';
               ?>
               <div class="large-6 columns">
                 <h2 class="contrast"><?php echo $feature_title;?></h2>
@@ -255,10 +256,12 @@
                   <img src="<?php echo $feature_image;?>" alt="">
                 <?php endif; ?>
                   <div class="panel">
-                    <header class="">
-                      <span class="external">Visit STEMcityPHL</span>
-                    </header>
-                    <hr class="mll mrl">
+                    <?php if( $feature_url_text != '' ): ?>
+                      <header class="">
+                        <span class="external"><?php echo $feature_url_text;?></span>
+                      </header>
+                      <hr class="mll mrl">
+                    <?php endif; ?>
                     <span class="details"><?php echo $feature_text;?></span>
                   </div>
                 <?php if( $feature_url != '' ): ?>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
@@ -91,20 +91,10 @@
               <!-- Display Custom Text -->
               <section class="row mvl">
                 <div class="large-24 column">
-                  <?php if ( !empty( $custom_text['phila_custom_text_title'] ) ) :?>
-                    <h2 class="contrast"><?php echo($custom_text['phila_custom_text_title']); ?></h2>
-                  <?php endif; ?>
-                  <?php if ( !empty( $custom_text['phila_custom_text_content'] ) ) :?>
-                    <div>
-                      <?php echo($custom_text['phila_custom_text_content']); ?>
-                    </div>
-                  <?php else :?>
-                    <div class="placeholder">
-                      Please enter content.
-                    </div>
-                  <?php endif; ?>
+                  <?php include(locate_template('partials/departments/content-custom-text.php'));?>
                 </div>
               </section>
+
             <?php endif; ?>
           <?php elseif ( $current_row_option == 'phila_list_items'): ?>
             <?php
@@ -120,23 +110,13 @@
         $current_row_option_two = $current_row['phila_half_options'] ['phila_half_col_2']; ?>
         <section class="row mvl">
             <?php if ( $current_row_option_one['phila_half_col_1_option'] == 'phila_custom_text'):?>
+
               <?php if ( isset( $current_row_option_one['phila_custom_text'] ) ):
                 $custom_text = $current_row_option_one['phila_custom_text']; ?>
-                  <div class="large-12 columns">
-                    <?php if ( !empty( $custom_text['phila_custom_text_title'] ) ) :?>
-                      <h2 class="contrast"><?php echo($custom_text['phila_custom_text_title']); ?></h2>
-                    <?php endif; ?>
-                    <?php if ( !empty( $custom_text['phila_custom_text_content'] ) ) :?>
-                      <div>
-                        <?php echo($custom_text['phila_custom_text_content']); ?>
-                      </div>
-                    <?php else :?>
-                      <div class="placeholder">
-                        Please enter content.
-                      </div>
-                    <?php endif; ?>
-                  </div>
-              <?php endif; ?>
+                <div class="large-12 columns">
+                  <?php include(locate_template('partials/departments/content-custom-text.php'));?>
+                </div>
+              <?php endif;?>
 
             <?php elseif ( $current_row_option_one['phila_half_col_1_option'] == 'phila_pullquote'):
               $pullquote = isset ($current_row_option_one['phila_pullquote'] ) ? $current_row_option_one['phila_pullquote'] : '';
@@ -151,24 +131,12 @@
             <?php endif; ?>
 
             <?php if ( $current_row_option_two['phila_half_col_2_option'] == 'phila_custom_text'):?>
-
                 <?php if ( isset( $current_row_option_two['phila_custom_text'] ) ):
                   $custom_text = $current_row_option_two['phila_custom_text']; ?>
-                    <div class="large-12 columns">
-                      <?php if ( !empty( $custom_text['phila_custom_text_title'] ) ) :?>
-                        <h2 class="contrast"><?php echo($custom_text['phila_custom_text_title']); ?></h2>
-                      <?php endif; ?>
-                      <?php if ( !empty( $custom_text['phila_custom_text_content'] ) ) :?>
-                        <div>
-                          <?php echo($custom_text['phila_custom_text_content']); ?>
-                        </div>
-                      <?php else :?>
-                        <div class="placeholder">
-                          Please enter content.
-                        </div>
-                      <?php endif; ?>
-                    </div>
-                <?php endif; ?>
+                  <div class="large-12 columns">
+                    <?php include(locate_template('partials/departments/content-custom-text.php'));?>
+                  </div>
+                <?php endif;?>
 
             <?php elseif ( $current_row_option_two['phila_half_col_2_option'] == 'phila_pullquote'):
               $pullquote = isset ($current_row_option_two['phila_pullquote'] ) ? $current_row_option_two['phila_pullquote'] : '';
@@ -201,33 +169,18 @@
                 </div>
               </div>
             <?php elseif ( $current_row_option_one['phila_two_thirds_col_option'] == 'phila_custom_text'):?>
-
                 <?php if ( isset( $current_row_option_one['phila_custom_text'] ) ):
                   $custom_text = $current_row_option_one['phila_custom_text']; ?>
-                  <!-- Custom Text -->
-                    <div class="large-18 columns">
-                      <?php if ( !empty( $custom_text['phila_custom_text_title'] ) ) :?>
-                        <h2 class="contrast"><?php echo($custom_text['phila_custom_text_title']); ?></h2>
-                      <?php endif; ?>
-                      <?php if ( !empty( $custom_text['phila_custom_text_content'] ) ) :?>
-                        <div>
-                          <?php echo($custom_text['phila_custom_text_content']); ?>
-                        </div>
-                      <?php else :?>
-                        <div class="placeholder">
-                          Please enter content.
-                        </div>
-                      <?php endif; ?>
-                    </div>
-                <?php endif; ?>
+                  <div class="large-18 columns">
+                    <?php include(locate_template('partials/departments/content-custom-text.php'));?>
+                  </div>
+                <?php endif;?>
 
             <?php elseif ( $current_row_option_one['phila_two_thirds_col_option'] == 'phila_custom_text_multi'):?>
-              <?php
-                $custom_text = isset ( $current_row_option_one['phila_custom_text_multi'] ) ? $current_row_option_one['phila_custom_text_multi'] : '';
-                if ( !empty($custom_text) ):
-                  include(locate_template('partials/departments/content-custom-text-multi.php'));
-                endif;
-              ?>
+              <?php if ( isset( $current_row_option_one['phila_custom_text_multi'] ) ):
+                $custom_text = $current_row_option_one['phila_custom_text_multi'];
+                include(locate_template('partials/departments/content-custom-text-multi.php'));
+              endif; ?>
 
             <?php endif;?>
 

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
@@ -21,29 +21,38 @@
           $current_row_option = $current_row['phila_full_options']['phila_full_options_select'];
 
           if ( $current_row_option == 'phila_blog_posts'):
-            $blog_category = isset( $current_row['phila_full_options']['phila_blog_options']['phila_category'] ) ? $current_row['phila_full_options']['phila_blog_options']['phila_category'] : '';
-        ?>
+            $blog_category = isset( $current_row['phila_full_options']['phila_blog_options']['phila_category'] ) ? $current_row['phila_full_options']['phila_blog_options']['phila_category'] : ''; ?>
             <!-- Blog Content -->
             <section class="row mvl">
                 <?php echo do_shortcode('[recent-posts posts="3" category="' . $blog_category . '"]'); ?>
             </section>
 
-          <?php elseif ( $current_row_option == 'phila_full_width_calendar'): ?>
-            <!-- Full Width Calendar -->
-            <?php
-              //TODO: verify that these vars exist before setting... offload to function?
-              $cal_id = $current_row['phila_full_options']['phila_full_width_calendar']['phila_full_width_calendar_id'];
-              $cal_url = $current_row['phila_full_options']['phila_full_width_calendar']['phila_full_width_calendar_url'];
-            ?>
-            <section class="row expanded calendar-row mbm ptm">
-              <div class="columns">
-                <h2>Events</h2>
-              </div>
-              <div class="medium-centered large-16 columns">
-                <?php echo do_shortcode('[calendar id="' . $cal_id . '"]'); ?>
-              </div>
-            </section>
+          <?php elseif ( $current_row_option == 'phila_full_width_calendar'):
+            $cal_id = isset( $current_row['phila_full_options']['phila_full_width_calendar']['phila_full_width_calendar_id'] ) ? $current_row['phila_full_options']['phila_full_width_calendar']['phila_full_width_calendar_id'] : '';
+            $cal_url = isset( $current_row['phila_full_options']['phila_full_width_calendar']['phila_full_width_calendar_url'] ) ? $current_row['phila_full_options']['phila_full_width_calendar']['phila_full_width_calendar_url'] : ''; ?>
 
+            <?php if ( !empty( $cal_id ) ):?>
+              <!-- Full Width Calendar -->
+              <section class="expanded">
+                <div class="row">
+                  <div class="columns">
+                    <h2>Events</h2>
+                  </div>
+                </div>
+                <div class="row expanded calendar-row mbm ptm">
+                  <div class="medium-centered large-16 columns">
+                    <?php echo do_shortcode('[calendar id="' . $cal_id . '"]'); ?>
+                  </div>
+                </div>
+                <?php if ( !empty( $cal_url ) ):?>
+                  <div class="row">
+                    <div class="columns">
+                      <a class="float-right see-all-right" href="<?php echo $cal_url; ?>">All Events</a>
+                      </div>
+                  </div>
+                <?php endif; ?>
+              </section>
+            <?php endif;?>
           <?php elseif ( $current_row_option == 'phila_callout'): ?>
             <!-- Display Callout -->
             <?php
@@ -75,6 +84,7 @@
                 $phila_dept_homepage_cta = $current_row['phila_full_options']['phila_call_to_action_multi']['phila_call_to_action_section'];
                 include(locate_template('partials/departments/content-call-to-action-multi.php'));
             endif; ?>
+
           <?php elseif ( $current_row_option == 'phila_custom_text'): ?>
             <!-- Display Custom Text -->
             <?php if ( isset( $current_row['phila_full_options']['phila_custom_text'] ) ):
@@ -109,8 +119,6 @@
         $current_row_option_two = $current_row['phila_half_options'] ['phila_half_col_2']; ?>
         <section class="row mvl">
             <?php if ( $current_row_option_one['phila_half_col_1_option'] == 'phila_custom_text'):?>
-
-
               <?php if ( isset( $current_row_option_one['phila_custom_text'] ) ):
                 $custom_text = $current_row_option_one['phila_custom_text']; ?>
                   <div class="large-12 columns">

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
@@ -53,17 +53,19 @@
                 <?php endif; ?>
               </section>
             <?php endif;?>
-          <?php elseif ( $current_row_option == 'phila_callout'): ?>
-            <!-- Display Callout -->
-            <?php
-              $callout_type = $current_row['phila_full_options']['phila_callout']['phila_callout_type'];
-              $callout_text = $current_row['phila_full_options']['phila_callout']['phila_callout_text'];
-            ?>
-            <section class="row mvm">
-              <div class="large-24 column">
-                  <?php echo do_shortcode('[callout summary="' . $callout_text . '" type="' . $callout_type . '" inline="false"]'); ?>
-              </div>
-            </section>
+
+          <?php elseif ( $current_row_option == 'phila_callout'):
+            $callout_type = isset( $current_row['phila_full_options']['phila_callout']['phila_callout_type'] ) ? $current_row['phila_full_options']['phila_callout']['phila_callout_type'] : '';
+            $callout_text = isset( $current_row['phila_full_options']['phila_callout']['phila_callout_text'] ) ? $current_row['phila_full_options']['phila_callout']['phila_callout_text'] : ''; ?>
+
+            <?php if ( !empty( $callout_text ) ): ?>
+              <!-- Display Callout -->
+              <section class="row mvm">
+                <div class="large-24 column">
+                    <?php echo do_shortcode('[callout summary="' . $callout_text . '" type="' . $callout_type . '" inline="false"]'); ?>
+                </div>
+              </section>
+            <?php endif;?>
 
           <?php elseif ($current_row_option == 'phila_get_involved'): ?>
             <!-- Display Multi Call to Action as Get Involved -->

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
@@ -138,13 +138,17 @@
                   </div>
               <?php endif; ?>
 
-            <?php elseif ( $current_row_option_one['phila_half_col_1_option'] == 'phila_pullquote'):?>
-              <?php $pullquote = $current_row_option_two['phila_pullquote'];?>
-              <div class="large-12 columns">
-                <?php echo do_shortcode('[pullquote quote="' . $pullquote['phila_quote'] . '" attribution="' . $pullquote['phila_attribution'] . '" inline="false"]'); ?>
-              </div>
-            <?php endif; ?>
+            <?php elseif ( $current_row_option_one['phila_half_col_1_option'] == 'phila_pullquote'):
+              $pullquote = isset ($current_row_option_two['phila_pullquote'] ) ? $current_row_option_two['phila_pullquote'] : '';
+              $quote = isset( $pullquote['phila_quote'] ) ? $pullquote['phila_quote'] : '';
+              $attribution = isset( $pullquote['phila_attribution'] ) ? $pullquote['phila_attribution'] : '';
 
+              if ( !empty( $quote ) ): ?>
+                <div class="large-12 columns">
+                  <?php echo do_shortcode('[pullquote quote="' . $quote . '" attribution="' . $attribution . '" inline="false"]'); ?>
+                </div>
+              <?php endif; ?>
+            <?php endif; ?>
 
             <?php if ( $current_row_option_two['phila_half_col_2_option'] == 'phila_custom_text'):?>
               <?php $custom_text = $current_row_option_one['phila_custom_text']; ?>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
@@ -80,7 +80,6 @@
               </section>
 
           <?php elseif ($current_row_option == 'phila_resource_list'): ?>
-            <!-- Display Multi Call to Action as Resource List -->
             <?php if ( isset( $current_row['phila_full_options']['phila_call_to_action_multi']['phila_call_to_action_section'] ) ):
                 $phila_dept_homepage_cta = $current_row['phila_full_options']['phila_call_to_action_multi']['phila_call_to_action_section'];
                 include(locate_template('partials/departments/content-call-to-action-multi.php'));

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
@@ -184,8 +184,8 @@
 
             <?php endif;?>
 
-              <?php
-                if ( $current_row_option_two['phila_one_third_col_option'] == 'phila_connect_panel'):
+            <?php
+              if ( $current_row_option_two['phila_one_third_col_option'] == 'phila_connect_panel'):
                 $connect_panel = $current_row_option_two['phila_connect_panel'];
 
                 // Set Connect Panel vars
@@ -199,7 +199,7 @@
                   $feature_text = isset( $feature_panel['phila_feature_text'] ) ? $feature_panel['phila_feature_text'] : '';
                   $feature_url = isset( $feature_panel['phila_feature_url'] ) ? $feature_panel['phila_feature_url'] : '';
                   $feature_url_text = isset( $feature_panel['phila_feature_url_text'] ) ? $feature_panel['phila_feature_url_text'] : '';
-              ?>
+            ?>
               <div class="large-6 columns">
                 <h2 class="contrast"><?php echo $feature_title;?></h2>
                 <?php if( $feature_url != '' ): ?>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
@@ -58,10 +58,10 @@
 
           <?php elseif ($current_row_option == 'phila_get_involved'): ?>
             <!-- Display Multi Call to Action as Get Involved -->
-            <?php
+            <?php if ( isset( $current_row['phila_full_options']['phila_call_to_action_multi']['phila_call_to_action_section'] ) ):
               $phila_dept_homepage_cta = $current_row['phila_full_options']['phila_call_to_action_multi']['phila_call_to_action_section'];
-              include(locate_template('partials/departments/content-get-involved.php'));
-            ?>
+                include(locate_template('partials/departments/content-get-involved.php'));
+            endif; ?>
 
           <?php elseif ( $current_row_option == 'phila_full_width_press_releases'): ?>
             <!-- Press Releases -->
@@ -71,27 +71,30 @@
 
           <?php elseif ($current_row_option == 'phila_resource_list'): ?>
             <!-- Display Multi Call to Action as Resource List -->
-            <?php
-              $phila_dept_homepage_cta = $current_row['phila_full_options']['phila_call_to_action_multi']['phila_call_to_action_section'];
-              include(locate_template('partials/departments/content-call-to-action-multi.php'));
-            ?>
-
+            <?php if ( isset( $current_row['phila_full_options']['phila_call_to_action_multi']['phila_call_to_action_section'] ) ):
+                $phila_dept_homepage_cta = $current_row['phila_full_options']['phila_call_to_action_multi']['phila_call_to_action_section'];
+                include(locate_template('partials/departments/content-call-to-action-multi.php'));
+            endif; ?>
           <?php elseif ( $current_row_option == 'phila_custom_text'): ?>
             <!-- Display Custom Text -->
-            <?php $custom_text = $current_row['phila_full_options']['phila_custom_text']; ?>
-              <section class="row mvl">
+            <?php if ( isset( $current_row['phila_full_options']['phila_custom_text'] ) ):
+              $custom_text = $current_row['phila_full_options']['phila_custom_text'];?>              <section class="row mvl">
                 <div class="large-24 column">
-                  <h2 class="contrast"><?php echo($custom_text['phila_custom_text_title']); ?></h2>
-                  <div>
-                    <?php echo($custom_text['phila_custom_text_content']); ?>
-                  </div>
-                  <?php if ( $custom_text == '' ) :?>
+                  <?php if ( !empty( $custom_text['phila_custom_text_title'] ) ) :?>
+                    <h2 class="contrast"><?php echo($custom_text['phila_custom_text_title']); ?></h2>
+                  <?php endif; ?>
+                  <?php if ( !empty( $custom_text['phila_custom_text_content'] ) ) :?>
+                    <div>
+                      <?php echo($custom_text['phila_custom_text_content']); ?>
+                    </div>
+                  <?php else :?>
                     <div class="placeholder">
                       Please enter content.
                     </div>
                   <?php endif; ?>
                 </div>
               </section>
+            <?php endif; ?>
           <?php elseif ( $current_row_option == 'phila_list_items'): ?>
             <?php
               $list_items = isset( $current_row['phila_full_options']['phila_list_items'] ) ? $current_row['phila_full_options']['phila_list_items'] : '';
@@ -106,19 +109,25 @@
         $current_row_option_two = $current_row['phila_half_options'] ['phila_half_col_2']; ?>
         <section class="row mvl">
             <?php if ( $current_row_option_one['phila_half_col_1_option'] == 'phila_custom_text'):?>
-              <?php $custom_text = $current_row_option_one['phila_custom_text']; ?>
 
-                <div class="large-12 columns">
-                  <h2 class="contrast"><?php echo($custom_text['phila_custom_text_title']); ?></h2>
-                  <div>
-                    <?php echo($custom_text['phila_custom_text_content']); ?>
+
+              <?php if ( isset( $current_row_option_one['phila_custom_text'] ) ):
+                $custom_text = $current_row_option_one['phila_custom_text']; ?>
+                  <div class="large-12 columns">
+                    <?php if ( !empty( $custom_text['phila_custom_text_title'] ) ) :?>
+                      <h2 class="contrast"><?php echo($custom_text['phila_custom_text_title']); ?></h2>
+                    <?php endif; ?>
+                    <?php if ( !empty( $custom_text['phila_custom_text_content'] ) ) :?>
+                      <div>
+                        <?php echo($custom_text['phila_custom_text_content']); ?>
+                      </div>
+                    <?php else :?>
+                      <div class="placeholder">
+                        Please enter content.
+                      </div>
+                    <?php endif; ?>
                   </div>
-                  <?php if ( $custom_text == '' ) :?>
-                    <div class="placeholder">
-                      Please enter content.
-                    </div>
-                  <?php endif; ?>
-                </div>
+              <?php endif; ?>
 
             <?php elseif ( $current_row_option_one['phila_half_col_1_option'] == 'phila_pullquote'):?>
               <?php $pullquote = $current_row_option_two['phila_pullquote'];?>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
@@ -184,22 +184,22 @@
 
             <?php endif;?>
 
-            <?php
-              if ( $current_row_option_two['phila_one_third_col_option'] == 'phila_connect_panel'):
-                $connect_panel = $current_row_option_two['phila_connect_panel'];
+            <?php if ( $current_row_option_two['phila_one_third_col_option'] == 'phila_connect_panel'):?>
+                <?php if ( isset( $current_row_option_two['phila_connect_panel'] ) ):
+                  $connect_panel = $current_row_option_two['phila_connect_panel'];
+                  $connect_vars = phila_connect_panel($connect_panel);
+                  include(locate_template('partials/departments/content-connect.php'));
+                endif; ?>
 
-                // Set Connect Panel vars
-                $connect_vars = phila_connect_panel($connect_panel);
-                include(locate_template('partials/departments/content-connect.php'));
-
-                elseif ( $current_row_option_two['phila_one_third_col_option'] == 'phila_custom_feature'):
-                  $feature_panel = isset( $current_row_option_two['phila_custom_feature'] ) ? $current_row_option_two['phila_custom_feature'] : '';
-                  $feature_title = isset( $feature_panel['phila_feature_title'] ) ? $feature_panel['phila_feature_title'] : '';
-                  $feature_image = isset( $feature_panel['phila_feature_image'] ) ? $feature_panel['phila_feature_image'] : '';
-                  $feature_text = isset( $feature_panel['phila_feature_text'] ) ? $feature_panel['phila_feature_text'] : '';
-                  $feature_url = isset( $feature_panel['phila_feature_url'] ) ? $feature_panel['phila_feature_url'] : '';
-                  $feature_url_text = isset( $feature_panel['phila_feature_url_text'] ) ? $feature_panel['phila_feature_url_text'] : '';
-            ?>
+            <?php elseif ( $current_row_option_two['phila_one_third_col_option'] == 'phila_custom_feature'):?>
+              <?php if ( isset( $current_row_option_two['phila_custom_feature'] ) ):
+                $feature_panel = $current_row_option_two['phila_custom_feature'];
+                $feature_title = isset( $feature_panel['phila_feature_title'] ) ? $feature_panel['phila_feature_title'] : '';
+                $feature_image = isset( $feature_panel['phila_feature_image'] ) ? $feature_panel['phila_feature_image'] : '';
+                $feature_text = isset( $feature_panel['phila_feature_text'] ) ? $feature_panel['phila_feature_text'] : '';
+                $feature_url = isset( $feature_panel['phila_feature_url'] ) ? $feature_panel['phila_feature_url'] : '';
+                $feature_url_text = isset( $feature_panel['phila_feature_url_text'] ) ? $feature_panel['phila_feature_url_text'] : '';
+              endif; ?>
               <div class="large-6 columns">
                 <h2 class="contrast"><?php echo $feature_title;?></h2>
                 <?php if( $feature_url != '' ): ?>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
@@ -15,7 +15,7 @@
       $current_row = $page_rows[$key];?>
 
       <!-- Grid Row -->
-      <?php if ( isset( $current_row['phila_grid_options'] ) && $current_row['phila_grid_options'] == 'phila_grid_options_full'):
+      <?php if ( ( isset( $current_row['phila_grid_options'] ) && $current_row['phila_grid_options'] == 'phila_grid_options_full' ) && isset( $current_row['phila_full_options']['phila_full_options_select'] ) ):
 
           // Begin full width row
           $current_row_option = $current_row['phila_full_options']['phila_full_options_select'];
@@ -103,11 +103,12 @@
             ?>
           <?php endif; ?>
 
-      <?php elseif ( isset( $current_row['phila_grid_options'] ) && $current_row['phila_grid_options'] == 'phila_grid_options_half'):
+      <?php elseif ( ( isset( $current_row['phila_grid_options'] ) && $current_row['phila_grid_options'] == 'phila_grid_options_half') && ( isset( $current_row['phila_half_options']['phila_half_col_1'] ) && isset( $current_row['phila_half_options']['phila_half_col_2'] ) ) ):
 
         // Begin 1/2 x 1/2 row
-        $current_row_option_one = $current_row['phila_half_options'] ['phila_half_col_1'];
-        $current_row_option_two = $current_row['phila_half_options'] ['phila_half_col_2']; ?>
+        $current_row_option_one = $current_row['phila_half_options']['phila_half_col_1'];
+        $current_row_option_two = $current_row['phila_half_options']['phila_half_col_2']; ?>
+
         <section class="row mvl">
             <?php if ( $current_row_option_one['phila_half_col_1_option'] == 'phila_custom_text'):?>
 
@@ -151,7 +152,7 @@
             <?php endif; ?>
 
         </section>
-      <?php elseif ( isset( $current_row['phila_grid_options'] ) && $current_row['phila_grid_options'] == 'phila_grid_options_thirds' ):
+      <?php elseif ( (isset( $current_row['phila_grid_options'] ) && $current_row['phila_grid_options'] == 'phila_grid_options_thirds' ) && ( isset($current_row['phila_two_thirds_options']['phila_two_thirds_col'] ) && isset( $current_row['phila_two_thirds_options']['phila_one_third_col'] ) ) ):
 
         // Begin 2/3 x 1/3 row
         $current_row_option_one = $current_row['phila_two_thirds_options']['phila_two_thirds_col'];
@@ -199,7 +200,7 @@
                 $feature_text = isset( $feature_panel['phila_feature_text'] ) ? $feature_panel['phila_feature_text'] : '';
                 $feature_url = isset( $feature_panel['phila_feature_url'] ) ? $feature_panel['phila_feature_url'] : '';
                 $feature_url_text = isset( $feature_panel['phila_feature_url_text'] ) ? $feature_panel['phila_feature_url_text'] : '';
-              endif; ?>
+              ?>
               <div class="large-6 columns">
                 <h2 class="contrast"><?php echo $feature_title;?></h2>
                 <?php if( $feature_url != '' ): ?>
@@ -222,6 +223,7 @@
                 <?php endif; ?>
               </div>
               <?php endif; ?>
+            <?php endif; ?>
         </section>
       <?php endif; ?>
     <!-- Grid Row -->

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
@@ -139,7 +139,7 @@
               <?php endif; ?>
 
             <?php elseif ( $current_row_option_one['phila_half_col_1_option'] == 'phila_pullquote'):
-              $pullquote = isset ($current_row_option_two['phila_pullquote'] ) ? $current_row_option_two['phila_pullquote'] : '';
+              $pullquote = isset ($current_row_option_one['phila_pullquote'] ) ? $current_row_option_one['phila_pullquote'] : '';
               $quote = isset( $pullquote['phila_quote'] ) ? $pullquote['phila_quote'] : '';
               $attribution = isset( $pullquote['phila_attribution'] ) ? $pullquote['phila_attribution'] : '';
 
@@ -170,11 +170,16 @@
                     </div>
                 <?php endif; ?>
 
-            <?php elseif ( $current_row_option_two['phila_half_col_2_option'] == 'phila_pullquote'):?>
-              <?php $pullquote = $current_row_option_two['phila_pullquote'];?>
-              <div class="large-12 columns">
-                <?php echo do_shortcode('[pullquote quote="' . $pullquote['phila_quote'] . '" attribution="' . $pullquote['phila_attribution'] . '" inline=false]'); ?>
-              </div>
+            <?php elseif ( $current_row_option_two['phila_half_col_2_option'] == 'phila_pullquote'):
+              $pullquote = isset ($current_row_option_two['phila_pullquote'] ) ? $current_row_option_two['phila_pullquote'] : '';
+              $quote = isset( $pullquote['phila_quote'] ) ? $pullquote['phila_quote'] : '';
+              $attribution = isset( $pullquote['phila_attribution'] ) ? $pullquote['phila_attribution'] : '';
+
+              if ( !empty( $quote ) ): ?>
+                <div class="large-12 columns">
+                  <?php echo do_shortcode('[pullquote quote="' . $quote . '" attribution="' . $attribution . '" inline="false"]'); ?>
+                </div>
+              <?php endif; ?>
             <?php endif; ?>
 
         </section>


### PR DESCRIPTION
This PR cleans up a few issues with the Department and Program & Initiative templates created during the sprint for MOE

- Better checking to make sure all necessary vars are declared before creating `row`s
- Consolidate repeated code in reusable partials 
- Where possible we intend to use `!empty()` instead of `$var != ''`, or `!$var ==''` when checking if a var is not empty
- Correct some errors in 1/2 x 1/2 column rows
- Some general markup clean up