### PR TITLE
Tax detail field tweaks

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes.php
@@ -1540,7 +1540,7 @@ $meta_var_document_page_selector = array(
   )
 );
 
-//Purpose: To display content in a wysiwyg or markup for an address
+//Purpose: To display content in a wysiwyg and include markup for an address
 $meta_var_wysiwyg_address_content = array(
   'id'  => $prefix . 'wysiwyg_address_content',
   'type'  => 'group',
@@ -1556,7 +1556,12 @@ $meta_var_wysiwyg_address_content = array(
       'class' => 'width-95'
     ),
     array(
-      'desc'  => 'Is this an address?',
+      'id'  => $prefix . 'wysiwyg_content',
+      'type'  => 'wysiwyg',
+      'options' => $wysiwyg_options_basic
+    ),
+    array(
+      'desc'  => 'Include an address?',
       'id'  => $prefix . 'address_select',
       'type'  => 'checkbox',
     ),
@@ -1569,12 +1574,6 @@ $meta_var_wysiwyg_address_content = array(
         $meta_var_standard_address,
       ),
     ),
-    array(
-      'id'  => $prefix . 'wysiwyg_content',
-      'visible' => array('phila_address_select', false),
-      'type'  => 'wysiwyg',
-      'options' => $wysiwyg_options_basic
-    )
   )
 );
 
@@ -1594,6 +1593,11 @@ $meta_var_ordered_content = array(
       'class' => 'width-95'
     ),
     array(
+      'id'  => $prefix . 'step_wysiwyg_content',
+      'type'  => 'wysiwyg',
+      'options' => $wysiwyg_options_basic
+    ),
+    array(
       'desc'  => 'Does this step contain an address?',
       'id'  => $prefix . 'address_step',
       'type'  => 'checkbox',
@@ -1607,12 +1611,6 @@ $meta_var_ordered_content = array(
         $meta_var_standard_address,
       ),
     ),
-    array(
-      'id'  => $prefix . 'step_wysiwyg_content',
-      'visible' => array('phila_address_step', false),
-      'type'  => 'wysiwyg',
-      'options' => $wysiwyg_options_basic
-    )
   )
 );
 

--- a/wp/wp-content/themes/phila.gov-theme/css/scss/_panel.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/_panel.scss
@@ -33,7 +33,7 @@
 .panel p{
   margin-bottom:1rem;
 
-    &:last-of-type {
+  &:last-of-type {
     margin: 0;
     padding: 0;
   }

--- a/wp/wp-content/themes/phila.gov-theme/css/scss/_panel.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/_panel.scss
@@ -32,8 +32,8 @@
 }
 .panel p{
   margin-bottom:1rem;
-}
-.panel p:last-of-type {
+
+  &:last-of-type {
   margin: 0;
   padding: 0;
 }

--- a/wp/wp-content/themes/phila.gov-theme/css/scss/_panel.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/_panel.scss
@@ -30,3 +30,10 @@
   font-size: $large-font-base;
   font-weight: 600;
 }
+.panel p{
+  margin-bottom:1rem;
+}
+.panel p:last-of-type {
+  margin: 0;
+  padding: 0;
+}

--- a/wp/wp-content/themes/phila.gov-theme/css/scss/_panel.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/_panel.scss
@@ -33,7 +33,8 @@
 .panel p{
   margin-bottom:1rem;
 
-  &:last-of-type {
-  margin: 0;
-  padding: 0;
+    &:last-of-type {
+    margin: 0;
+    padding: 0;
+  }
 }

--- a/wp/wp-content/themes/phila.gov-theme/partials/taxes/content-tax-detail.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/taxes/content-tax-detail.php
@@ -50,7 +50,7 @@
           <?php if ( !empty( $tax['cost']['number'] ) ) : ?>
             <div class="numbers mbm">
               <span class="symbol">
-                <?php echo ($tax['cost']['unit'] == 'dollar') ? '$' : ''; ?></span><span class="large-text"><?php echo $tax['cost']['number']; ?></span><span class="symbol"><?php echo ($tax['cost']['unit'] == 'percent') ? '%' : ''; ?><?php echo ($tax['cost']['unit'] == 'mil') ? 'mil' : '';
+                <?php echo ($tax['cost']['unit'] == 'dollar') ? '$' : ''; ?></span><span class="large-text"><?php echo $tax['cost']['number']; ?></span><span class="symbol"><?php echo ($tax['cost']['unit'] == 'percent') ? '%' : ''; ?><?php echo ($tax['cost']['unit'] == 'mil') ? 'mills' : '';
                   ?>
               </span>
             </div>

--- a/wp/wp-content/themes/phila.gov-theme/partials/taxes/content-tax-detail.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/taxes/content-tax-detail.php
@@ -55,7 +55,7 @@
               </span>
             </div>
           <?php endif; ?>
-        <div><?php echo $tax['cost']['summary_brief'] ?></div>
+        <div><?php echo apply_filters( 'the_content', $tax['cost']['summary_brief'] ); ?></div>
       </div>
     </div>
   </div>
@@ -168,7 +168,7 @@
                   <span class="postal-code"><?php echo $zip; ?></span>
                 </div>
               <?php else : ?>
-                <?php echo $wysiwyg_content;?>
+                <?php echo apply_filters( 'the_content', $wysiwyg_content ) ;?>
               <?php endif; ?>
 
             </div>

--- a/wp/wp-content/themes/phila.gov-theme/partials/taxes/content-tax-detail.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/taxes/content-tax-detail.php
@@ -146,6 +146,8 @@
             <div class="plm">
               <?php $wysiwyg_content = isset( $item['phila_wysiwyg_content'] ) ? $item['phila_wysiwyg_content'] : ''; ?>
 
+              <?php echo apply_filters( 'the_content', $wysiwyg_content ) ;?>
+
               <?php $is_address = isset( $item['phila_address_select'] ) ? $item['phila_address_select'] : '';
                ?>
                 <?php
@@ -167,10 +169,7 @@
                   <span class="locality"><?php echo $city; ?></span>, <span class="region" title="Pennsylvania"><?php echo $state; ?>
                   <span class="postal-code"><?php echo $zip; ?></span>
                 </div>
-              <?php else : ?>
-                <?php echo apply_filters( 'the_content', $wysiwyg_content ) ;?>
-              <?php endif; ?>
-
+                <?php endif;?>
             </div>
           </div>
         <?php endforeach; ?>
@@ -190,7 +189,9 @@
           <div class="step">
             <div class="step-title"><?php echo $step['phila_step_wysiwyg_heading'] ?></div>
             <div class="step-content">
-              <?php if ( $is_address == 1 ) : ?>
+              <?php $step_wysiwyg_content = isset( $item['phila_step_wysiwyg_content'] ) ? $item['phila_step_wysiwyg_content'] : ''; ?>
+
+              <?php  echo apply_filters( 'the_content', $step_wysiwyg_content ); ?>
                 <?php
                 $address_1 = isset( $step['phila_std_address']['address_group']['phila_std_address_st_1'] ) ? $step['phila_std_address']['address_group']['phila_std_address_st_1'] : '';
 
@@ -212,11 +213,6 @@
                 </div>
                 <?php endif; ?>
 
-              <?php else : ?>
-                <?php if ( !empty( $step['phila_step_wysiwyg_content'] ) ) :
-                  echo apply_filters( 'the_content', $step['phila_step_wysiwyg_content'] ); ?>
-                <?php endif; ?>
-              <?php endif; ?>
             </div>
           </div>
           <?php endforeach; ?>


### PR DESCRIPTION
* Allows user to enter _both_ wysiwyg content and address per heading area in "How to Pay" section
* Apply `the_content` filter to all fields with multi-line display
* Corrects "mil" to "mills"