### PR TITLE
Use get_permalink

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/public/class-content-collection-walker.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/class-content-collection-walker.php
@@ -34,7 +34,7 @@ class Content_Collection_Walker extends Walker_Page {
             $link_before .= '';
             $link_after = '' . $link_after;
         }
-        $output .= $indent . '<li' . $class_attr . '><a href="' . get_page_link($page->ID) . '">' . $link_before . apply_filters( 'the_title', $page->post_title, $page->ID ) . $link_after . '</a>';
+        $output .= $indent . '<li' . $class_attr . '><a href="' . get_permalink($page->ID) . '">' . $link_before . apply_filters( 'the_title', $page->post_title, $page->ID ) . $link_after . '</a>';
 
         if ( !empty($show_date) ) {
             if ( 'modified' == $show_date )


### PR DESCRIPTION
* `Content_Collection_Walker` had been using `get_page_link`, but we are now using this walker on more than just Pages. Update it to `get_permalink` to fix. 