### PR TITLE
Apply outlined-arrow style to "See all" links site-wide

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/blogs.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/blogs.php
@@ -108,7 +108,7 @@ function latest_posts_shortcode($atts) {
       $output .= '</ul>';
     }
 
-    $output .= '</div><a class="see-all-right see-all-arrow float-right" href="/posts/'. $category_slug . '">
+    $output .= '</div><a class="see-all-right see-all-arrow float-right" href="/posts/'. $category_slug . '" aria-label="See all ' . $a['name'] . '">
       <div class="valign equal-height">
         <div class="see-all-label phm prxs valign-cell equal">See all</div>
         <div class="valign-cell equal">

--- a/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/blogs.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/blogs.php
@@ -18,7 +18,7 @@ function latest_posts_shortcode($atts) {
   $a = shortcode_atts( array(
    'posts' => 1,
     0 => 'list',
-    'name' => 'Blog Posts',
+    'name' => 'Blog posts',
     'category' => '',
  ), $atts );
 
@@ -108,7 +108,7 @@ function latest_posts_shortcode($atts) {
       $output .= '</ul>';
     }
 
-    $output .= '</div><a class="see-all-right see-all-arrow float-right" href="/posts/'. $category_slug . '" aria-label="See all ' . $a['name'] . '">
+    $output .= '</div><a class="see-all-right see-all-arrow float-right" href="/posts/'. $category_slug . '" aria-label="See all ' . strtolower($a['name']) . '">
       <div class="valign equal-height">
         <div class="see-all-label phm prxs valign-cell equal">See all</div>
         <div class="valign-cell equal">

--- a/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/blogs.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/blogs.php
@@ -108,7 +108,14 @@ function latest_posts_shortcode($atts) {
       $output .= '</ul>';
     }
 
-    $output .= '</div><a class="see-all-right float-right" href="/posts/'. $category_slug . '">All ' . $a['name'] . '</a></div>';
+    $output .= '</div><a class="see-all-right see-all-arrow float-right" href="/posts/'. $category_slug . '">
+      <div class="valign equal-height">
+        <div class="see-all-label phm prxs valign-cell equal">See all</div>
+        <div class="valign-cell equal">
+          <img style="height:28px" src="' . get_stylesheet_directory_uri() . '/img/see-all-arrow.svg" alt="">
+        </div>
+      </div>
+    </a></div>';
 
     }else {
       $output .= __( 'Please enter at least one post.', 'phila.gov' );

--- a/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/news.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/news.php
@@ -131,7 +131,7 @@ function recent_news_shortcode($atts) {
     //  $output .= '</div>';
     }
 
-    $output .= '</div><a class="see-all-right see-all-arrow float-right" href="/news/'. $a['category'] . '" aria-label="See all ' . $a['name'] . '">
+    $output .= '</div><a class="see-all-right see-all-arrow float-right" href="/news/'. $a['category'] . '" aria-label="See all ' . strtolower($a['name']) . '">
       <div class="valign equal-height">
         <div class="see-all-label phm prxs valign-cell equal">See all</div>
         <div class="valign-cell equal">

--- a/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/news.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/news.php
@@ -131,8 +131,14 @@ function recent_news_shortcode($atts) {
     //  $output .= '</div>';
     }
 
-    $output .= '</div><a class="see-all-right float-right" href="/news/'. $a['category'] . '">All ' . $a['name'] . '</a></div>';
-
+    $output .= '</div><a class="see-all-right see-all-arrow float-right" href="/news/'. $a['category'] . '">
+      <div class="valign equal-height">
+        <div class="see-all-label phm prxs valign-cell equal">See all</div>
+        <div class="valign-cell equal">
+          <img style="height:28px" src="' . get_stylesheet_directory_uri() . '/img/see-all-arrow.svg" alt="">
+        </div>
+      </div>
+    </a></div>';
 
     }else {
       $output .= __( 'Please enter at least one news story.', 'phila.gov' );

--- a/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/news.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/news.php
@@ -131,7 +131,7 @@ function recent_news_shortcode($atts) {
     //  $output .= '</div>';
     }
 
-    $output .= '</div><a class="see-all-right see-all-arrow float-right" href="/news/'. $a['category'] . '">
+    $output .= '</div><a class="see-all-right see-all-arrow float-right" href="/news/'. $a['category'] . '" aria-label="See all ' . $a['name'] . '">
       <div class="valign equal-height">
         <div class="see-all-label phm prxs valign-cell equal">See all</div>
         <div class="valign-cell equal">

--- a/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/press-releases.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/press-releases.php
@@ -14,6 +14,7 @@ function press_release_shortcode($atts) {
   $category = get_the_category();
   $a = shortcode_atts( array(
    'posts' => 1,
+   'name' => 'Press Releases',
   ), $atts );
 
   $current_category = $category[0]->cat_ID;
@@ -68,8 +69,8 @@ function press_release_shortcode($atts) {
     endwhile;
 
     $output .= '</ul>';
-    
-    $output .= '</div><a class="see-all-right see-all-arrow float-right" href="/press-releases/'. $category_slug . '">
+
+    $output .= '</div><a class="see-all-right see-all-arrow float-right" href="/press-releases/'. $category_slug . '" aria-label="See all ' . $a['name'] . '">
       <div class="valign equal-height">
         <div class="see-all-label phm prxs valign-cell equal">See all</div>
         <div class="valign-cell equal">

--- a/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/press-releases.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/press-releases.php
@@ -14,7 +14,7 @@ function press_release_shortcode($atts) {
   $category = get_the_category();
   $a = shortcode_atts( array(
    'posts' => 1,
-   'name' => 'Press Releases',
+   'name' => 'Press releases',
   ), $atts );
 
   $current_category = $category[0]->cat_ID;
@@ -34,7 +34,7 @@ function press_release_shortcode($atts) {
   if( $press_release_loop->have_posts() ) {
     $post_counter = 0;
 
-    $output .= '<div class="large-24 columns"><h2 class="contrast">' . __('Press Releases', 'phila-gov') . '</h2><ul class="no-bullet pan border-bottom-list">';
+    $output .= '<div class="large-24 columns"><h2 class="contrast">' . __('Press releases', 'phila-gov') . '</h2><ul class="no-bullet pan border-bottom-list">';
 
     while( $press_release_loop->have_posts() ) :
       $press_release_loop->the_post();
@@ -70,7 +70,7 @@ function press_release_shortcode($atts) {
 
     $output .= '</ul>';
 
-    $output .= '</div><a class="see-all-right see-all-arrow float-right" href="/press-releases/'. $category_slug . '" aria-label="See all ' . $a['name'] . '">
+    $output .= '</div><a class="see-all-right see-all-arrow float-right" href="/press-releases/'. $category_slug . '" aria-label="See all ' . strtolower($a['name']) . '">
       <div class="valign equal-height">
         <div class="see-all-label phm prxs valign-cell equal">See all</div>
         <div class="valign-cell equal">

--- a/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/press-releases.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/press-releases.php
@@ -68,8 +68,15 @@ function press_release_shortcode($atts) {
     endwhile;
 
     $output .= '</ul>';
-
-    $output .= '<a class="see-all-right float-right" href="/press-releases/'. $category_slug . '">All ' . __('Press Releases', 'phila-gov'). '</a></div>';
+    
+    $output .= '</div><a class="see-all-right see-all-arrow float-right" href="/press-releases/'. $category_slug . '">
+      <div class="valign equal-height">
+        <div class="see-all-label phm prxs valign-cell equal">See all</div>
+        <div class="valign-cell equal">
+          <img style="height:28px" src="' . get_stylesheet_directory_uri() . '/img/see-all-arrow.svg" alt="">
+        </div>
+      </div>
+    </a></div>';
 
     }else {
       $output .= __( 'Please enter at least one press release.', 'phila.gov' );

--- a/wp/wp-content/themes/phila.gov-theme/front-page.php
+++ b/wp/wp-content/themes/phila.gov-theme/front-page.php
@@ -126,7 +126,7 @@ get_header(); ?>
             <div class="valign equal-height">
               <div class="see-all-label phm prxs valign-cell equal">See all</div>
               <div class="valign-cell equal">
-                <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . "/img/see-all-arrow.svg" ?>" alt="">
+                <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . "/img/see-all-arrow.svg"; ?>" alt="">
               </div>
             </div>
           </a>

--- a/wp/wp-content/themes/phila.gov-theme/front-page.php
+++ b/wp/wp-content/themes/phila.gov-theme/front-page.php
@@ -122,7 +122,7 @@ get_header(); ?>
               <div class="alert">No recent news.</div>
             <?php endif; ?>
           </div>
-          <a class="see-all-right see-all-arrow float-right" href="/news">
+          <a class="see-all-right see-all-arrow float-right" href="/news" aria-label="See all news">
             <div class="valign equal-height">
               <div class="see-all-label phm prxs valign-cell equal">See all</div>
               <div class="valign-cell equal">

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-call-to-action-multi.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-call-to-action-multi.php
@@ -78,7 +78,7 @@
         <div class="valign equal-height">
           <div class="see-all-label phm prxs valign-cell equal">See all</div>
           <div class="valign-cell equal">
-            <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . '/img/see-all-arrow.svg'; ?>" alt="">
+            <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . "/img/see-all-arrow.svg"; ?>" alt="">
           </div>
         </div>
       </a>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-call-to-action-multi.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-call-to-action-multi.php
@@ -74,7 +74,14 @@
   <?php endforeach; ?>
 <?php if ( $link_url != '' && $link_title != ''):?>
     <div class="columns">
-      <a class="see-all-right float-right" href="<?php echo $link_url; ?>"><?php echo $link_title; ?></a>
+      <a class="see-all-right see-all-arrow float-right" href="<?php echo $link_url; ?>" aria-label="See all <?php echo $action_panel_title; ?>">
+        <div class="valign equal-height">
+          <div class="see-all-label phm prxs valign-cell equal">See all</div>
+          <div class="valign-cell equal">
+            <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . '/img/see-all-arrow.svg'; ?>" alt="">
+          </div>
+        </div>
+      </a>
     </div>
 <?php endif; ?>
 </section>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-department-homepage.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-department-homepage.php
@@ -45,7 +45,14 @@
                   <?php if ( !empty( $cal_url ) ):?>
                     <div class="row">
                       <div class="columns">
-                        <a class="float-right see-all-right" href="<?php echo $cal_url; ?>">All Events</a>
+                        <a class="see-all-right see-all-arrow float-right" href="<?php echo $cal_url; ?>" aria-label="See all events">
+                          <div class="valign equal-height">
+                            <div class="see-all-label phm prxs valign-cell equal">See all</div>
+                            <div class="valign-cell equal">
+                              <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . '/img/see-all-arrow.svg' ?>" alt="">
+                            </div>
+                          </div>
+                        </a>
                         </div>
                     </div>
                   <?php endif; ?>
@@ -89,7 +96,7 @@
 
           <?php endif; ?>
         <?php elseif ( ( isset( $current_row['phila_grid_options'] ) && $current_row['phila_grid_options'] == 'phila_grid_options_thirds') && ( isset( $current_row['phila_two_thirds_options'] ['phila_two_thirds_col'] ) && isset( $current_row['phila_two_thirds_options'] ['phila_one_third_col'] ) ) ):
-          
+
           $current_row_option_one = $current_row['phila_two_thirds_options'] ['phila_two_thirds_col'];
           $current_row_option_two = $current_row['phila_two_thirds_options'] ['phila_one_third_col']; ?>
 

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-department-homepage.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-department-homepage.php
@@ -49,7 +49,7 @@
                           <div class="valign equal-height">
                             <div class="see-all-label phm prxs valign-cell equal">See all</div>
                             <div class="valign-cell equal">
-                              <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . '/img/see-all-arrow.svg' ?>" alt="">
+                              <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . "/img/see-all-arrow.svg"; ?>" alt="">
                             </div>
                           </div>
                         </a>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
@@ -47,8 +47,15 @@
                 <?php if ( !empty( $cal_url ) ):?>
                   <div class="row">
                     <div class="columns">
-                      <a class="float-right see-all-right" href="<?php echo $cal_url; ?>">All Events</a>
-                      </div>
+                      <a class="see-all-right see-all-arrow float-right" href="<?php echo $cal_url; ?>" aria-label="See all events">
+                        <div class="valign equal-height">
+                          <div class="see-all-label phm prxs valign-cell equal">See all</div>
+                          <div class="valign-cell equal">
+                            <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . "/img/see-all-arrow.svg"; ?>" alt="">
+                          </div>
+                        </div>
+                      </a>
+                    </div>
                   </div>
                 <?php endif; ?>
               </section>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-row-two.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-row-two.php
@@ -64,7 +64,7 @@ if (!empty($row_two_column_selection)) {
           <div class="valign equal-height">
             <div class="see-all-label phm prxs valign-cell equal">See all</div>
             <div class="valign-cell equal">
-              <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . "/img/see-all-arrow.svg" ?>" alt="">
+              <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . "/img/see-all-arrow.svg"; ?>" alt="">
             </div>
           </div>
         </a>
@@ -87,7 +87,7 @@ if (!empty($row_two_column_selection)) {
              <div class="valign equal-height">
                <div class="see-all-label phm prxs valign-cell equal">See all</div>
                <div class="valign-cell equal">
-                 <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . "/img/see-all-arrow.svg" ?>" alt="">
+                 <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . "/img/see-all-arrow.svg"; ?>" alt="">
                </div>
              </div>
            </a>
@@ -111,7 +111,7 @@ if (!empty($row_two_column_selection)) {
                <div class="valign equal-height">
                  <div class="see-all-label phm prxs valign-cell equal">See all</div>
                  <div class="valign-cell equal">
-                   <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . "/img/see-all-arrow.svg" ?>" alt="">
+                   <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . "/img/see-all-arrow.svg"; ?>" alt="">
                  </div>
                </div>
              </a>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-row-two.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-row-two.php
@@ -60,7 +60,7 @@ if (!empty($row_two_column_selection)) {
   <?php if ( !empty($row_two_full_col_cal_url) ):?>
     <div class="row">
       <div class="columns">
-        <a class="see-all-right see-all-arrow float-right" href="<?php echo $row_two_full_col_cal_url; ?>">
+        <a class="see-all-right see-all-arrow float-right" href="<?php echo $row_two_full_col_cal_url; ?>" aria-label="See all events">
           <div class="valign equal-height">
             <div class="see-all-label phm prxs valign-cell equal">See all</div>
             <div class="valign-cell equal">
@@ -83,7 +83,7 @@ if (!empty($row_two_column_selection)) {
            <?php echo do_shortcode('[calendar id="' . $row_two_col_one_cal_id .'"]'); ?>
          </div>
          <?php if ($row_two_col_one_cal_url):?>
-           <a class="see-all-right see-all-arrow float-right" href="<?php echo $row_two_col_one_cal_url; ?>">
+           <a class="see-all-right see-all-arrow float-right" href="<?php echo $row_two_col_one_cal_url; ?>" aria-label="See all events">
              <div class="valign equal-height">
                <div class="see-all-label phm prxs valign-cell equal">See all</div>
                <div class="valign-cell equal">
@@ -107,7 +107,7 @@ if (!empty($row_two_column_selection)) {
              <?php echo do_shortcode('[calendar id="' . $row_two_col_two_cal_id .'"]'); ?>
            </div>
            <?php if ($row_two_col_one_cal_url):?>
-             <a class="see-all-right see-all-arrow float-right" href="<?php echo $row_two_col_two_cal_url; ?>">
+             <a class="see-all-right see-all-arrow float-right" href="<?php echo $row_two_col_two_cal_url; ?>" aria-label="See all events">
                <div class="valign equal-height">
                  <div class="see-all-label phm prxs valign-cell equal">See all</div>
                  <div class="valign-cell equal">

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-row-two.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-row-two.php
@@ -60,8 +60,15 @@ if (!empty($row_two_column_selection)) {
   <?php if ( !empty($row_two_full_col_cal_url) ):?>
     <div class="row">
       <div class="columns">
-        <a class="float-right see-all-right" href="<?php echo $row_two_full_col_cal_url; ?>">All Events</a>
-        </div>
+        <a class="see-all-right see-all-arrow float-right" href="<?php echo $row_two_full_col_cal_url; ?>">
+          <div class="valign equal-height">
+            <div class="see-all-label phm prxs valign-cell equal">See all</div>
+            <div class="valign-cell equal">
+              <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . "/img/see-all-arrow.svg" ?>" alt="">
+            </div>
+          </div>
+        </a>
+      </div>
     </div>
   <?php endif; ?>
  <?php endif; ?>
@@ -76,7 +83,14 @@ if (!empty($row_two_column_selection)) {
            <?php echo do_shortcode('[calendar id="' . $row_two_col_one_cal_id .'"]'); ?>
          </div>
          <?php if ($row_two_col_one_cal_url):?>
-           <a class="float-right see-all-right" href="<?php echo $row_two_col_one_cal_url; ?>">All Events</a>
+           <a class="see-all-right see-all-arrow float-right" href="<?php echo $row_two_col_one_cal_url; ?>">
+             <div class="valign equal-height">
+               <div class="see-all-label phm prxs valign-cell equal">See all</div>
+               <div class="valign-cell equal">
+                 <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . "/img/see-all-arrow.svg" ?>" alt="">
+               </div>
+             </div>
+           </a>
          <?php endif; ?>
        </div>
      <?php elseif ( $row_two_col_one_type  == 'phila_module_row_2_col_1_press_release' ): ?>
@@ -92,8 +106,14 @@ if (!empty($row_two_column_selection)) {
            <div class="event-box">
              <?php echo do_shortcode('[calendar id="' . $row_two_col_two_cal_id .'"]'); ?>
            </div>
-           <?php if ($row_two_col_one_cal_url):?>
-             <a class="float-right see-all-right" href="<?php echo $row_two_col_two_cal_url; ?>">All Events</a>
+           <a class="see-all-right see-all-arrow float-right" href="<?php echo $row_two_col_two_cal_url; ?>">
+             <div class="valign equal-height">
+               <div class="see-all-label phm prxs valign-cell equal">See all</div>
+               <div class="valign-cell equal">
+                 <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . "/img/see-all-arrow.svg" ?>" alt="">
+               </div>
+             </div>
+           </a>
            <?php endif; ?>
         </div>
        <?php elseif ( $row_two_col_two_type  == 'phila_module_row_2_col_2_press_release' ): ?>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-row-two.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-row-two.php
@@ -106,14 +106,15 @@ if (!empty($row_two_column_selection)) {
            <div class="event-box">
              <?php echo do_shortcode('[calendar id="' . $row_two_col_two_cal_id .'"]'); ?>
            </div>
-           <a class="see-all-right see-all-arrow float-right" href="<?php echo $row_two_col_two_cal_url; ?>">
-             <div class="valign equal-height">
-               <div class="see-all-label phm prxs valign-cell equal">See all</div>
-               <div class="valign-cell equal">
-                 <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . "/img/see-all-arrow.svg" ?>" alt="">
+           <?php if ($row_two_col_one_cal_url):?>
+             <a class="see-all-right see-all-arrow float-right" href="<?php echo $row_two_col_two_cal_url; ?>">
+               <div class="valign equal-height">
+                 <div class="see-all-label phm prxs valign-cell equal">See all</div>
+                 <div class="valign-cell equal">
+                   <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . "/img/see-all-arrow.svg" ?>" alt="">
+                 </div>
                </div>
-             </div>
-           </a>
+             </a>
            <?php endif; ?>
         </div>
        <?php elseif ( $row_two_col_two_type  == 'phila_module_row_2_col_2_press_release' ): ?>

--- a/wp/wp-content/themes/phila.gov-theme/single-event_page.php
+++ b/wp/wp-content/themes/phila.gov-theme/single-event_page.php
@@ -35,7 +35,9 @@ get_header(); ?>
             $event_end_date = rwmb_meta('phila_event_end' , $args = array('type' => 'date'));
             $event_connect = rwmb_meta('phila_event_connect' , $args = array('type' => 'textarea'));
 
+            //FIXME: incorrect var names. should be event_content_blocks
             $event_contact_blocks_header = rwmb_meta('phila_event_content_blocks_heading' , $args = array('type' => 'text'));
+            //TODO: remove phila_event_content_blocks_link_text meta-box option
             $event_contact_blocks_link_text = rwmb_meta('phila_event_content_blocks_link_text' , $args = array('type' => 'text'));
             $event_contact_blocks_link = rwmb_meta('phila_event_content_blocks_link' , $args = array('type' => 'url'));
 
@@ -278,8 +280,15 @@ get_header(); ?>
             </div>
           <?php endif; ?>
           <?php if (!$event_contact_blocks_link == ''): ?>
-            <?php $link_text = (!$event_contact_blocks_link_text=='') ? $event_contact_blocks_link_text : "More"; ?>
-            <a class="see-all-right float-right" href="<?php echo $event_contact_blocks_link;?>"><?php echo $link_text ?></a>
+            <?php $link_text = (!$event_contact_blocks_link_text=='') ? $event_contact_blocks_link_text : ""; ?>
+            <a class="see-all-right see-all-arrow float-right" href="<?php echo $event_contact_blocks_link;?>" aria-label="See all <?php echo strtolower( $event_contact_blocks_header ); ?>">
+              <div class="valign equal-height">
+                <div class="see-all-label phm prxs valign-cell equal">See all</div>
+                <div class="valign-cell equal">
+                  <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . '/img/see-all-arrow.svg'; ?>" alt="">
+                </div>
+              </div>
+            </a>
           <?php endif; ?>
         </div>
       </div>

--- a/wp/wp-content/themes/phila.gov-theme/single-event_page.php
+++ b/wp/wp-content/themes/phila.gov-theme/single-event_page.php
@@ -285,7 +285,7 @@ get_header(); ?>
               <div class="valign equal-height">
                 <div class="see-all-label phm prxs valign-cell equal">See all</div>
                 <div class="valign-cell equal">
-                  <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . '/img/see-all-arrow.svg'; ?>" alt="">
+                  <img style="height:28px" src="<?php echo get_stylesheet_directory_uri() . "/img/see-all-arrow.svg"; ?>" alt="">
                 </div>
               </div>
             </a>


### PR DESCRIPTION
This PR adds the blue outlined-arrow style to the the "See all" links being generated in the following locations.

**Shortcodes**

- blogs.php
- news.php
- press-releases

**Other**

- front-page.php (news area)

**Templates/Partials**

- content-call-to-action-multi.php
- content-department-homepage.php
- content-programs-initiatives.php
- content-row-two.php (calendar/events)
- single-event_page.php