### PR TITLE
Enclosed callout shortcode

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/callout.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/callout.php
@@ -9,7 +9,6 @@
 */
 function callout_shortcode($atts, $content=null){
   $a = shortcode_atts( array(
-    //'summary' => '',
     'type' => '',
     'inline' => 'true',
   ), $atts);
@@ -20,16 +19,8 @@ function callout_shortcode($atts, $content=null){
     $output .= '<div class="callout';
 
     $output .= $a['type'] == 'important' ? ' ' . $a['type'] . ' ' : ' ';
-    // if($a['type'] == 'important') {
-    //   $output .= ' ' . $a['type'] . ' ';
-    // }
 
     $output .= $a['inline'] == 'true' ? 'mtl">' : 'mbn">';
-    // if($a['inline'] == 'true') {
-    //   $output .= 'mtl">';
-    // } else  {
-    //     $output .= 'mbn">';
-    // }
 
     $output .= '<p>' . $content . '</p>';
     $output .= '</div>';

--- a/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/callout.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/callout.php
@@ -7,29 +7,31 @@
 *
 * @package phila-gov_customization
 */
-function callout_shortcode($atts){
+function callout_shortcode($atts, $content=null){
   $a = shortcode_atts( array(
-    'summary' => '',
+    //'summary' => '',
     'type' => '',
     'inline' => 'true',
   ), $atts);
 
   $output = '';
 
-  if ( $a['summary'] != '' ){
+  if ( $content != '' ){
     $output .= '<div class="callout';
 
-    if($a['type'] == 'important') {
-      $output .= ' ' . $a['type'] . ' ';
-    }
+    $output .= $a['type'] == 'important' ? ' ' . $a['type'] . ' ' : ' ';
+    // if($a['type'] == 'important') {
+    //   $output .= ' ' . $a['type'] . ' ';
+    // }
 
-    if($a['inline'] == 'true') {
-      $output .= 'mtl">';
-    } else  {
-        $output .= 'mbn">';
-    }
+    $output .= $a['inline'] == 'true' ? 'mtl">' : 'mbn">';
+    // if($a['inline'] == 'true') {
+    //   $output .= 'mtl">';
+    // } else  {
+    //     $output .= 'mbn">';
+    // }
 
-    $output .= '<p>' . $a['summary'] . '</p>';
+    $output .= '<p>' . $content . '</p>';
     $output .= '</div>';
 
     return $output;

--- a/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/callout.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/callout.php
@@ -13,6 +13,16 @@ function callout_shortcode($atts, $content=null){
     'inline' => 'true',
   ), $atts);
 
+  $allowed_html = [
+    'a'      => [
+        'href'  => [],
+        'title' => [],
+      ],
+    'br'     => [],
+    'em'     => [],
+    'strong' => [],
+  ];
+
   $output = '';
 
   if ( $content != '' ){
@@ -22,7 +32,7 @@ function callout_shortcode($atts, $content=null){
 
     $output .= $a['inline'] == 'true' ? 'mtl">' : 'mbn">';
 
-    $output .= '<p>' . $content . '</p>';
+    $output .= '<p>' . wp_kses($content, $allowed_html). '</p>';
     $output .= '</div>';
 
     return $output;

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
@@ -69,7 +69,7 @@
               <!-- Display Callout -->
               <section class="row mvm">
                 <div class="large-24 column">
-                    <?php echo do_shortcode('[callout summary="' . $callout_text . '" type="' . $callout_type . '" inline="false"]'); ?>
+                    <?php echo do_shortcode('[callout type="' . $callout_type . '" inline="false"]' . $callout_text . '[/callout]'); ?>
                 </div>
               </section>
             <?php endif;?>


### PR DESCRIPTION
- Convert callout.php to an enclosed shortcode. 
- Sanitize `$content` with `wp_kses()` (allowing only `a`, `br`,`em`,`strong` elements)