### PR TITLE
Standardize thumbnails

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/blogs.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/blogs.php
@@ -72,7 +72,7 @@ function latest_posts_shortcode($atts) {
     if ( is_flag( 'list', $atts ) ){
       $output .= '<li class="group mbm pbm">';
 
-      $output .=  get_the_post_thumbnail( $post->ID, 'news-thumb', 'class= small-thumb mrm' );
+      $output .=  get_the_post_thumbnail( $post->ID, 'phila-thumb', 'class= small-thumb mrm' );
 
       $output .= 	'<span class="entry-date small-text">'. get_the_date() . '</span>';
       $output .= '<a href="' . get_permalink() .'"><h3>' . get_the_title( $post->ID ) . '</h3></a>';

--- a/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/news.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/news.php
@@ -91,7 +91,7 @@ function recent_news_shortcode($atts) {
 
       $output .= '<a href="' . $link .'" class="group">';
 
-      $output .=  get_the_post_thumbnail( $post->ID, 'news-thumb', 'class=alignleft small-thumb' );
+      $output .=  get_the_post_thumbnail( $post->ID, 'phila-thumb', 'class=alignleft small-thumb' );
       $output .= '<div class="pbm"><span class="entry-date small-text">'. get_the_date() . '</span>';
       $output .=  '<h3>' . get_the_title( $post->ID ) . '</h3>';
       $output .= '<span class="small-text">' . wp_strip_all_tags( $desc ) . '</span>';

--- a/wp/wp-content/themes/phila.gov-theme/css/scss/beta/_utils.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/beta/_utils.scss
@@ -180,3 +180,8 @@ html.is-reveal-open{
   }
   @extend .hover-fade;
 }
+//TODO: increase this size
+.phila-thumb img{
+  max-width: 250px;
+  height: auto;
+}

--- a/wp/wp-content/themes/phila.gov-theme/functions.php
+++ b/wp/wp-content/themes/phila.gov-theme/functions.php
@@ -49,8 +49,6 @@ function phila_gov_setup() {
   // Current default
   add_image_size( 'phila-thumb', 660, 430, true);
 
-  add_image_size( 'news-thumb', 250, 165, true );
-
   //This is temporary, until we decide how to handle responsive images more effectively and in what ratios.
   add_image_size( 'home-thumb', 550, 360, true );
 

--- a/wp/wp-content/themes/phila.gov-theme/partials/content-single-news.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/content-single-news.php
@@ -19,10 +19,10 @@
     <div data-swiftype-index='true' class="entry-content medium-24 columns">
       <?php
       if ( has_post_thumbnail() ) : ?>
-            <?php
-              $large_image_url = wp_get_attachment_image_src( get_post_thumbnail_id(), 'full' );
-              the_post_thumbnail( 'news-thumb' , array( 'class' => 'float-left hide-for-small-only' ) );
-      endif;
+      <div class="phila-thumb float-left mrm mvm">
+        <?php echo phila_get_thumbnails(); ?>
+      </div>
+      <?php endif;
       $desc = phila_get_item_meta_desc( );
       if ($post->post_content != ''):
         the_content();

--- a/wp/wp-content/themes/phila.gov-theme/partials/content-single-post.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/content-single-post.php
@@ -28,8 +28,9 @@
       <div class="posted-on row column pvs">
       <?php if ( has_post_thumbnail() ): ?>
         <div class="columns hide-for-small-only medium-24 pan">
-          <?php $large_image_url = wp_get_attachment_image_src( get_post_thumbnail_id(), 'full' );
-          the_post_thumbnail( 'news-thumb' ); ?>
+          <div class="phila-thumb float-left mrm mvm">
+            <?php echo phila_get_thumbnails(); ?>
+          </div>
         </div>
         <?php endif; ?>
         <div class="byline small-24 column pvm pvs-mu">


### PR DESCRIPTION
- Remove references to deprecated `news-thumb`, except in fallback. 