### PR TITLE
Add "noninteractive" in case user input is required

### DIFF
--- a/scripts/predeploy.sh
+++ b/scripts/predeploy.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
 /usr/local/bin/aws s3 cp s3://phila-prod-environment/environment /home/ubuntu/.ssh/environment
+
+export DEBIAN_FRONTEND=noninteractive
+
 sudo apt-get update
 sudo apt-get upgrade -y


### PR DESCRIPTION
Hopefully, prevent user input from interrupting predeploy.