### PR TITLE
Include callouts

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-standard-metaboxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-standard-metaboxes.php
@@ -6,7 +6,7 @@ if ( class_exists('Phila_Gov_Standard_Metaboxes' ) ){
 
  class Phila_Gov_Standard_Metaboxes {
 
-  public static function phila_wysiwyg_options_basic(){
+  public static function phila_wysiwyg_options_basic( $editor_height = 200 ){
 
     return array(
       'media_buttons' => false,
@@ -18,7 +18,7 @@ if ( class_exists('Phila_Gov_Standard_Metaboxes' ) ){
           'format_select' => false
          )
        ),
-      'editor_height' => 200,
+      'editor_height' => $editor_height,
     );
   }
 

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/tax-detail-fields.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/tax-detail-fields.php
@@ -145,6 +145,16 @@ function phila_register_tax_detail_meta_boxes( $meta_boxes ){
         'type'   => 'group',
 
         'fields'  => array(
+          array(
+            'name' => 'Important changes about this tax',
+            'type'  => 'heading'
+          ),
+          array(
+            'id'  => 'phila_wysiwyg_callout',
+            'type'  => 'wysiwyg',
+            'options' =>
+            Phila_Gov_Standard_Metaboxes::phila_wysiwyg_options_basic( 100 )
+          ),
           $meta_var_tax_due_date,
           array(
             'type'  => 'divider'

--- a/wp/wp-content/themes/phila.gov-theme/functions.php
+++ b/wp/wp-content/themes/phila.gov-theme/functions.php
@@ -1480,6 +1480,8 @@ function phila_tax_highlight( $info_panel ){
   if ( !empty($info_panel) ){
 
     foreach ( $info_panel as $k ){
+      $output['callout'] = isset( $info_panel['phila_wysiwyg_callout'] ) ? $info_panel['phila_wysiwyg_callout'] : '';
+
       $output['due'] = array();
 
       $output['due']['type'] = isset(

--- a/wp/wp-content/themes/phila.gov-theme/partials/taxes/content-tax-detail.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/taxes/content-tax-detail.php
@@ -22,6 +22,13 @@
   $more = phila_additional_content( $additional_content );
 
 ?>
+<?php if ($tax['callout'] != '') :?>
+<div class="row">
+  <div class="columns mbl">
+    <?php echo do_shortcode('[callout type="important" inline="false"]' . $tax['callout'] . '[/callout]'); ?>
+  </div>
+</div>
+<?php endif; ?>
 <div class="row equal-height">
   <div class="medium-12 columns">
     <div class="panel info center heading">


### PR DESCRIPTION
* Create admin fields for collecting changing tax information. 
* To be used when details about a tax are changing to give notice to users that there will be (and subsequently has been) a change. 

* Update `phila_wysiwyg_options_basic` with parameter to change height of editor when reused. 