### PR TITLE
Hotfix

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-item-meta-desc.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-item-meta-desc.php
@@ -9,17 +9,11 @@ if ( class_exists("Phila_Item_Meta_Desc" ) ){
 
   public function __construct(){
 
-    add_filter( 'rwmb_meta_boxes', array($this, 'phila_register_item_desc_meta_boxes' ), 10, 1 );
+    add_filter( 'rwmb_meta_boxes', array($this, 'phila_register_item_desc_meta_boxes' ), 1000, 1 );
 
   }
 
   function phila_register_item_desc_meta_boxes( $meta_boxes ){
-    $post_types = array(
-      'public'  => true,
-      '_builtin'  => true
-    );
-
-    $public_post_types = get_post_types( $post_types, $output = 'names', $operator = 'or' );
 
     $prefix = 'phila_';
 
@@ -28,8 +22,11 @@ if ( class_exists("Phila_Item_Meta_Desc" ) ){
       'title' => 'Short Description',
       'context'  => 'advanced',
       'priority' => 'high',
-
-      'pages' => $public_post_types,
+      
+      //TODO: replace this with a function that pulls the post types we need. It had been set up this way, but after a WP update, get_post_types was not returning CPTs. A quick fix needed to be put in place, and this is it.
+      'post_types' => array(
+        'phila_post', 'news_post',  'department_page', 'service_page', 'document', 'press_release', 'event_page', 'page'
+      ),
 
       'fields' => array(
         array(

--- a/wp/wp-content/themes/phila.gov-theme/partials/content-single-news.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/content-single-news.php
@@ -22,16 +22,9 @@
       <div class="phila-thumb float-left mrm mvm">
         <?php echo phila_get_thumbnails(); ?>
       </div>
-      <?php endif;
-      $desc = phila_get_item_meta_desc( );
-      if ($post->post_content != ''):
-        the_content();
-      else :
-        if ($news_desc) :
-          echo '<p class="description">' . $desc . '</p>';
-        endif;
-      endif;
-      ?>
+    <?php endif; ?>
+
+      <?php the_content(); ?>
     </div><!-- .entry-content -->
   </div><!-- .row -->
 </article><!-- #post-## -->

--- a/wp/wp-content/themes/phila.gov-theme/partials/content-single-post.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/content-single-post.php
@@ -12,16 +12,7 @@
   </div>
   <div class="row mvm">
     <div data-swiftype-index='true' class="entry-content medium-18 medium-push-6 columns">
-
-    <?php
-      $desc = phila_get_item_meta_desc( );
-
-      if ($post->post_content != ''):
-        the_content();
-      else :
-        echo '<p class="description">' . $desc . '</p>';
-      endif;
-      ?>
+    <?php the_content(); ?>
     </div>
     <aside id="secondary" class="small-24 medium-6 medium-pull-18 columns prm">
       <?php $posted_on_values = phila_get_posted_on(); ?>


### PR DESCRIPTION
Corrects a problem where description fields were being rendered on the front end, when they shouldn't have been. Also identified an issue where `get_post_types` was not returning the correct list.