### PR TITLE
Connect hotfix

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/meta-boxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/meta-boxes.php
@@ -758,6 +758,8 @@ function phila_register_meta_boxes( $meta_boxes ){
                   'type' => 'email',
                   'desc' => 'example@phila.gov',
                 ),
+                Phila_Gov_Standard_Metaboxes::phila_metabox_url('See all link', 'connect_see_all'),
+
               ),
             ),
           ),

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/v2/content-connect.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/v2/content-connect.php
@@ -60,7 +60,7 @@ $connect_vars = phila_connect_panel($connect_panel);
     </div>
     </div>
   </div>
-
+  <?php if ( ( !$connect_vars['phone'] == '' ) || (!$connect_vars['fax'] == '' ) ) : ?>
   <div class="row collapse equal-height inside-border-group">
     <div class="small-5 columns equal center inside-border-group-item">
       <div class="valign">
@@ -72,11 +72,9 @@ $connect_vars = phila_connect_panel($connect_panel);
     <div class="small-19 columns equal inside-border-group-item">
       <div class="valign">
         <div class="valign-cell phm pvl">
-          <?php if ( !$connect_vars['phone'] == '') : ?>
             <div class="tel">
               <span class="type <?php echo ( !$connect_vars['fax'] ) ? 'accessible' : '';?>">Phone: </span><a href="tel:<?php echo preg_replace('/[^A-Za-z0-9]/', '', $connect_vars['phone']); ?>" class="value"><?php echo $connect_vars['phone']; ?></a>
             </div>
-          <?php endif; ?>
           <?php if ( !$connect_vars['fax'] == '') : ?>
             <div class="fax">
               <span class="type">Fax: </span><span class="value"><?php echo $connect_vars['fax']; ?></span>
@@ -86,6 +84,7 @@ $connect_vars = phila_connect_panel($connect_panel);
       </div>
     </div>
   </div>
+<?php endif; ?>
 
   <div class="row collapse equal-height inside-border-group">
     <div class="small-5 columns equal center inside-border-group-item">


### PR DESCRIPTION
- Corrects display of connect block if no phone or fax is entered. 
- Adds option to render "see all" connect link.

Users were not correctly identifying who they were calling from a single contact number. This solution gives users the ability to see a full list of potential contact options, hopefully mitigating incorrect phone calls. 