### PR TITLE
Staff hotfix

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-standard-metaboxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-standard-metaboxes.php
@@ -479,4 +479,14 @@ if ( class_exists('Phila_Gov_Standard_Metaboxes' ) ){
       'post_type' => $post_type,
     );
   }
+
+  public static function phila_metabox_category_single_select( $name, $id ){
+    return array(
+      'name' => $name,
+      'id' => $id,
+      'type' => 'taxonomy',
+      'taxonomy' => 'category',
+      'field_type'  => 'select',
+    );
+  }
 }

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-standard-metaboxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-standard-metaboxes.php
@@ -471,7 +471,6 @@ if ( class_exists('Phila_Gov_Standard_Metaboxes' ) ){
   }
 
   public static function phila_metabox_post_picker( $name, $id, $post_type ){
-
     return array(
       'name' => $name,
       'id' => $id,
@@ -484,7 +483,7 @@ if ( class_exists('Phila_Gov_Standard_Metaboxes' ) ){
     return array(
       'name' => $name,
       'id' => $id,
-      'type' => 'taxonomy',
+      'type' => 'taxonomy_advanced',
       'taxonomy' => 'category',
       'field_type'  => 'select',
     );

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/v2-departments.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/v2-departments.php
@@ -171,6 +171,16 @@ function phila_register_department_meta_boxes( $meta_boxes ){
   );
 
 
+  $meta_boxes[] = array(
+    'title' => 'Select category',
+    'pages'    => array( 'department_page' ),
+    'visible' => array( 'phila_template_select', 'staff_directory_v2' ),
+
+    'fields' => array(
+      Phila_Gov_Standard_Metaboxes::phila_metabox_category_single_select('Get staff in this category only (overrides page Category selection)', 'phila_staff_category')
+    ),
+  );
+
 
   return $meta_boxes;
 }

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-staff-directory.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-staff-directory.php
@@ -9,9 +9,18 @@
 
 $user_selected_template = phila_get_selected_template();
 
-if (has_category()):
+$category_override = rwmb_meta('phila_staff_category');
+
+
+if( has_category() ):
+
   $categories = get_the_category();
   $category_id = $categories[0]->cat_ID;
+
+  if (isset( $category_override ) ) :
+    $category_id = $category_override->term_id;
+  endif;
+
   $staff_leadership_array = array();
   // The Staff Directory Loop
   $args = array ( 'orderby' => 'title', 'order' => 'ASC', 'post_type' => 'staff_directory', 'cat' => $category_id, 'posts_per_page' => -1 );


### PR DESCRIPTION
Allow category override on Staff pages to account for multiple category assignment.

Adds new phila standard metabox for category selection, `phila_metabox_category_single_select`.