### PR TITLE
Staff hotfix

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-standard-metaboxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-standard-metaboxes.php
@@ -479,13 +479,4 @@ if ( class_exists('Phila_Gov_Standard_Metaboxes' ) ){
     );
   }
 
-  public static function phila_metabox_category_single_select( $name, $id ){
-    return array(
-      'name' => $name,
-      'id' => $id,
-      'type' => 'taxonomy_advanced',
-      'taxonomy' => 'category',
-      'field_type'  => 'select',
-    );
-  }
 }

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/v2-departments.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/v2-departments.php
@@ -177,8 +177,11 @@ function phila_register_department_meta_boxes( $meta_boxes ){
     'visible' => array( 'phila_template_select', 'staff_directory_v2' ),
 
     'fields' => array(
-      Phila_Gov_Standard_Metaboxes::phila_metabox_category_single_select('Get staff in this category only (overrides page Category selection)', 'phila_staff_category')
-    ),
+      'name' => 'Get staff in this category only -- overrides page Category selection',
+      'id' => 'phila_staff_category',
+      'type' => 'taxonomy_advanced',
+      'taxonomy' => 'category',
+    )
   );
 
 

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-staff-directory.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-staff-directory.php
@@ -11,14 +11,13 @@ $user_selected_template = phila_get_selected_template();
 
 $category_override = rwmb_meta('phila_staff_category');
 
-
-if( has_category() ):
+if ( has_category() ):
 
   $categories = get_the_category();
   $category_id = $categories[0]->cat_ID;
 
-  if (isset( $category_override ) ) :
-    $category_id = $category_override->term_id;
+  if ( !empty( $category_override ) ) :
+    $category_id = $category_override;
   endif;
 
   $staff_leadership_array = array();


### PR DESCRIPTION
* `phila-metabox` standard wasn't working with the `taxonomy-advanced` field type. Removing it for now. 