### PR TITLE
Address search: Use AIS instead of OPA API

### DIFF
--- a/wp/wp-content/themes/phila.gov-theme/css/scss/_swiftype.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/_swiftype.scss
@@ -27,7 +27,7 @@
   }
   .property-link {
     border: 3px solid $flyers-orange;
-    display: block;
+    display: none;
     padding: 0.3rem 0.5rem;
 
     p {

--- a/wp/wp-content/themes/phila.gov-theme/js/dev/search.js
+++ b/wp/wp-content/themes/phila.gov-theme/js/dev/search.js
@@ -65,10 +65,9 @@ hashQuery();
 
 var addressRe = /\d+ \w+/;
 var $propertyLink = $('#property-link');
+
 function addressSearch () {
   // Also check OPA API for results if it looks like an address
-
-  $propertyLink.hide();
 
   var params = $.deparam(location.hash.substr(1));
   var query = params.stq;

--- a/wp/wp-content/themes/phila.gov-theme/js/dev/search.js
+++ b/wp/wp-content/themes/phila.gov-theme/js/dev/search.js
@@ -75,8 +75,10 @@ function addressSearch () {
   var queryEncoded = encodeURIComponent(query);
 
   if (addressRe.test(params.stq)) {
-    $.ajax('https://api.phila.gov/opa/v1.1/address/' + queryEncoded + '/?format=json',
-      {dataType: $.support.cors ? 'json' : 'jsonp'})
+    $.ajax('https://api.phila.gov/ais/v1/addresses/' + queryEncoded, {
+        dataType: $.support.cors ? 'json' : 'jsonp',
+        data: { gatekeeperKey: '1e4f98f7cb9f4c2ffeb9eb369cfb26bf' }
+      })
       .done(function (data) {
         if (data.total) {
           $propertyLink.prop('href', '/property/?a=' + queryEncoded + '&u=');

--- a/wp/wp-content/themes/phila.gov-theme/js/dev/search.js
+++ b/wp/wp-content/themes/phila.gov-theme/js/dev/search.js
@@ -78,12 +78,12 @@ function addressSearch () {
         dataType: $.support.cors ? 'json' : 'jsonp',
         data: { gatekeeperKey: 'ad0050d3c6e40064546a18af371f7826' }
       })
-      .done(function (data) {
-        if (data.total) {
-          $propertyLink.prop('href', '/property/?a=' + queryEncoded + '&u=');
-          $propertyLink.show();
-        }
-      });
+    .done(function (data) {
+      if (data.total_size) {
+        $propertyLink.prop('href', '/property/?a=' + queryEncoded + '&u=');
+        $propertyLink.css('display', 'block');
+      }
+    });
   }
 }
 

--- a/wp/wp-content/themes/phila.gov-theme/js/dev/search.js
+++ b/wp/wp-content/themes/phila.gov-theme/js/dev/search.js
@@ -77,7 +77,7 @@ function addressSearch () {
   if (addressRe.test(params.stq)) {
     $.ajax('https://api.phila.gov/ais/v1/addresses/' + queryEncoded, {
         dataType: $.support.cors ? 'json' : 'jsonp',
-        data: { gatekeeperKey: '1e4f98f7cb9f4c2ffeb9eb369cfb26bf' }
+        data: { gatekeeperKey: 'ad0050d3c6e40064546a18af371f7826' }
       })
       .done(function (data) {
         if (data.total) {


### PR DESCRIPTION
If you search an address on beta.phila.gov, the website detects that it's an address and lets you forward your search to property. [example](https://beta.phila.gov/search/#stq=1234%20market). But the OPA API is deprecated; it should use AIS.

@tswanson or @rbrtmrtn is this API key okay, or should we use a unique one?

@kdemi I haven't tested this; can you test before merging?