### PR TITLE
Document pages

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-admin-documents.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-admin-documents.php
@@ -44,7 +44,7 @@ if ( class_exists("Phila_Gov_Admin_Documents" ) ){
     if(!$documents == null) {
 
       foreach ($documents as $document){
-        $current_pdf = $document[ID];
+        $current_pdf = $document['ID'];
 
         $categories = get_the_category($post_id);
 

--- a/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-admin-documents.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-admin-documents.php
@@ -55,12 +55,6 @@ if ( class_exists("Phila_Gov_Admin_Documents" ) ){
           wp_add_object_terms( $current_pdf, $category_ids, 'category' );
         }
 
-        $types =  get_the_terms( $post_id, 'document_type' );
-
-        foreach ($types as $type){
-          $type_ids[] = $type->term_id;
-          wp_set_object_terms( $current_pdf, $type_ids, 'document_type', false );
-        }
       }
       $list = get_post_meta($post_id, 'phila_documents');
     }

--- a/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-custom-post-types.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-custom-post-types.php
@@ -233,7 +233,6 @@ class Phila_Gov_Custom_Post_Types{
         ),
         'taxonomies' => array(
           'category',
-          'document_type'
         ),
         'supports' => array(
           'title',

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/meta-boxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/meta-boxes.php
@@ -125,7 +125,12 @@ function phila_register_meta_boxes( $meta_boxes ){
          'name' => ' Release Date',
        ),
        array(
-        'desc'  => 'Set the release date for all items on this document page. You can change an individual release date by editing the document below.',
+         'name' => '',
+         'id'   => 'phila_override_release_date',
+         'desc'  => 'Override all individual release dates on this document page with the date selected below?',
+         'type' => 'checkbox',
+       ),
+       array(
         'id'    => 'phila_document_released',
         'type'  => 'date',
         'class' =>  'document-released',

--- a/wp/wp-content/themes/phila.gov-theme/templates/documents.php
+++ b/wp/wp-content/themes/phila.gov-theme/templates/documents.php
@@ -9,7 +9,7 @@
   </header><!-- .entry-header -->
 </div>
 <div class="row">
-  <div data-swiftype-index='true' class="entry-content small-24 columns">
+  <div data-swiftype-index="true" class="entry-content small-24 columns">
     <?php
     //Documents are using a wysiwyg editor for body content
     $document_description = rwmb_meta( 'phila_document_description' );

--- a/wp/wp-content/themes/phila.gov-theme/templates/documents.php
+++ b/wp/wp-content/themes/phila.gov-theme/templates/documents.php
@@ -13,6 +13,7 @@
     <?php
     //Documents are using a wysiwyg editor for body content
     $document_description = rwmb_meta( 'phila_document_description' );
+    $date_override = rwmb_meta( 'phila_override_release_date' );
     $global_document_published = rwmb_meta( 'phila_document_released', $args = array( 'type' => 'date' ) );
 
     $documents = rwmb_meta( 'phila_files', $args = array( 'type' => 'file_advanced' ) );
@@ -44,6 +45,10 @@
       $file_type = $attachment_data['subtype'];
       $content = $attachment_data['description'];
       $document_published = rwmb_meta( 'phila_document_page_release_date', $args = array(), $post_id = $id[0] );
+
+      if ( empty($document_published) ){
+        $document_published = get_the_date( $d = '', $id[0] );
+      }
       ?>
       <tr class="clickable-row" data-href="<?php echo $document['url']; ?>">
         <td>
@@ -57,10 +62,10 @@
             <?php endif; ?>
           </td>
           <td>
-            <?php if( ! $document_published == '' ): ?>
-              <?php echo $document_published; ?>
-            <?php else: ?>
+            <?php if ($date_override === '1') : ?>
               <?php echo $global_document_published; ?>
+            <?php else: ?>
+              <?php echo $document_published; ?>
             <?php endif; ?>
           </td>
           <td>


### PR DESCRIPTION
* Correct rendering issue with some document pages
* Remove `document_type`  taxonomy

Change document page date workflow to the following: 

* Date is automatically set to date the item was uploaded.
* If the uploaded date is not the release date, allow for per-item date setting.
* If all the documents on the page should have the same release date, override the settings above and use global page date.