### PR TITLE
Add subscribers to admin author list

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-role-administration.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-role-administration.php
@@ -21,6 +21,9 @@ class Phila_Gov_Role_Administration {
 
     add_action( 'admin_enqueue_scripts', array( $this, 'administration_admin_scripts'), 1000 );
 
+    add_filter( 'wp_dropdown_users_args', array( $this, 'add_subscribers_to_author_dropdown'), 10, 2 );
+
+
   }
 
   /**
@@ -295,6 +298,13 @@ class Phila_Gov_Role_Administration {
     if ( is_admin() ){
       $current_user_cat = $this->get_current_user_category();
     }
+
+  }
+
+  function add_subscribers_to_author_dropdown( $query_args, $r ) {
+
+    $query_args['who'] = '';
+    return $query_args;
 
   }
 


### PR DESCRIPTION
Give users who don't have access to post content (subscribers) the ability to get "credit" for what they have written. Future changes could include a custom role that does the same thing, in the event that we actually do something with subscriber user profiles. 