### PR TITLE
Set static server_name

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -41,9 +41,14 @@ http {
   {{/PHILA_TEST}}
     include server.d/*.conf;
   }
-    
+
   server {
     server_name alpha-test.phila.gov    alpha.phila.gov;
     return 301 $scheme://beta.phila.gov$request_uri;
   }
+
+  server {
+    server_name beta.phila.gov www.beta.phila.gov;
+  }
+
 }


### PR DESCRIPTION
Set static sever_name to prevent HTTP Host header attacks.