### PR TITLE
Only remove right & left padding

### DIFF
--- a/wp/wp-content/themes/phila.gov-theme/css/scss/beta/_inside-border.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/beta/_inside-border.scss
@@ -3,7 +3,8 @@
 
   .inside-border-group-item{
     border: 1px solid $white;
-    padding:0;
+    padding-left:0;
+    padding-right:0;
 
     > a{
       &:hover{


### PR DESCRIPTION
* Overrides column padding to allow for full-width hover states. Allows for vertical padding in connect boxes. 