### PR TITLE
Category selection

### DIFF
--- a/wp/wp-content/plugins/meta-box/inc/interfaces/storage.php
+++ b/wp/wp-content/plugins/meta-box/inc/interfaces/storage.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Storage interface
+ *
+ * @package Meta Box
+ */
+
+/**
+ * Interface RWMB_Storage_Interface
+ */
+interface RWMB_Storage_Interface {
+
+	/**
+	 * Get value from storage.
+	 *
+	 * @param  int    $object_id Object id.
+	 * @param  string $name      Field name.
+	 * @param  array  $args      Custom arguments..
+	 * @return mixed
+	 */
+	public function get( $object_id, $name, $args = array() );
+}

--- a/wp/wp-content/plugins/meta-box/inc/storage-registry.php
+++ b/wp/wp-content/plugins/meta-box/inc/storage-registry.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Storage registry class
+ *
+ * @package Meta Box
+ */
+
+/**
+ * Class RWMB_Storage_Registry
+ */
+class RWMB_Storage_Registry {
+
+	/**
+	 * List storage instances.
+	 *
+	 * @var array
+	 */
+	protected $storages = array();
+
+	/**
+	 * Get storage instance.
+	 *
+	 * @param string $class_name Storage class name.
+	 * @return RWMB_Storage_Interface
+	 */
+	public function get( $class_name ) {
+		if ( empty( $this->storages[ $class_name ] ) ) {
+			$this->storages[ $class_name ] = new $class_name();
+		}
+
+		return $this->storages[ $class_name ];
+	}
+}

--- a/wp/wp-content/plugins/meta-box/inc/storages/post.php
+++ b/wp/wp-content/plugins/meta-box/inc/storages/post.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Post storage
+ *
+ * @package Meta Box
+ */
+
+/**
+ * Class RWMB_Post_Storage
+ */
+class RWMB_Post_Storage implements RWMB_Storage_Interface {
+
+	/**
+	 * Get value from storage.
+	 *
+	 * @param  int    $object_id Object id.
+	 * @param  string $name      Field name.
+	 * @param  array  $args      Custom arguments.
+	 * @return mixed
+	 */
+	public function get( $object_id, $name, $args = array() ) {
+		$single = ! empty( $args['single'] );
+		return get_post_meta( $object_id, $name, $single );
+	}
+}

--- a/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-custom-post-types.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-custom-post-types.php
@@ -136,7 +136,6 @@ class Phila_Gov_Custom_Post_Types{
       'exclude_from_search' => true,
       'public' => false,
       'show_in_rest' => true,
-      'rest_base' => 'service_updates',
       'show_ui' => true,
       'has_archive' => false,
       'menu_icon' => 'dashicons-warning',

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-standard-metaboxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-standard-metaboxes.php
@@ -487,4 +487,17 @@ if ( class_exists('Phila_Gov_Standard_Metaboxes' ) ){
     );
   }
 
+  public static function phila_metabox_category_picker( $name, $id, $post_type, $clone = false, $max_clone = 3, $columns = '12' ){
+    return array(
+      'name'  => $name,
+      'id'  => $id,
+      'clone' => $clone,
+      'max_clone' => $max_clone,
+      'columns' => $columns,
+      'type'  => 'taxonomy_advanced',
+      'taxonomy'  => 'category',
+      'field_type'  => 'select_advanced'
+    );
+  }
+
 }

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-standard-metaboxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-standard-metaboxes.php
@@ -487,7 +487,7 @@ if ( class_exists('Phila_Gov_Standard_Metaboxes' ) ){
     );
   }
 
-  public static function phila_metabox_category_picker( $name, $id, $desc){
+  public static function phila_metabox_category_picker( $name, $id, $desc = ''){
     return array(
       'name'  => $name,
       'id'  => $id,

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-standard-metaboxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-standard-metaboxes.php
@@ -487,12 +487,11 @@ if ( class_exists('Phila_Gov_Standard_Metaboxes' ) ){
     );
   }
 
-  public static function phila_metabox_category_picker( $name, $id, $post_type, $clone = false, $max_clone = 3, $columns = '12' ){
+  public static function phila_metabox_category_picker( $name, $id, $post_type, $columns = '12' ){
     return array(
       'name'  => $name,
       'id'  => $id,
-      'clone' => $clone,
-      'max_clone' => $max_clone,
+      'post_type' => $post_type,
       'columns' => $columns,
       'type'  => 'taxonomy_advanced',
       'taxonomy'  => 'category',

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-standard-metaboxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-standard-metaboxes.php
@@ -487,15 +487,16 @@ if ( class_exists('Phila_Gov_Standard_Metaboxes' ) ){
     );
   }
 
-  public static function phila_metabox_category_picker( $name, $id, $post_type, $columns = '12' ){
+  public static function phila_metabox_category_picker( $name, $id, $desc){
     return array(
       'name'  => $name,
       'id'  => $id,
-      'post_type' => $post_type,
-      'columns' => $columns,
+      'desc'  => $desc,
       'type'  => 'taxonomy_advanced',
       'taxonomy'  => 'category',
-      'field_type'  => 'select_advanced'
+      'field_type'  => 'select_advanced',
+      'multiple'  => true,
+      'allowClear' => true
     );
   }
 

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/meta-boxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/meta-boxes.php
@@ -1022,6 +1022,41 @@ $meta_boxes[] = array(
   );
 
   $meta_boxes[] = array(
+    'id'       => 'phila_full_row_news',
+    'title'    => 'Full row news posts (3 total)',
+    'pages'    => array( 'department_page' ),
+    'context'  => 'normal',
+    'priority' => 'low',
+
+    'include' => array(
+      'user_role'  => array( 'administrator', 'primary_department_homepage_editor', 'editor' ),
+    ),
+    'visible' => array(
+      'when' => array(
+        array( 'phila_template_select', '=', 'homepage_v2'),
+      ),
+      'relation' => 'or',
+    ),
+
+    'fields' => array(
+      array(
+        'name' => '',
+        'id'   => 'phila_full_row_news_selected',
+        'desc'  => 'Should this page show a full row of news items?',
+        'type' => 'checkbox',
+        'after' => '<p class="description">Enter at least three news posts in the <a href="/wp-admin/edit.php?post_type=news_post">News</a> section.</p>'
+      ),
+      array(
+        'id'  => 'phila_get_news_cats',
+        'type' => 'group',
+        'fields' => array(
+          Phila_Gov_Standard_Metaboxes::phila_metabox_category_picker('Select new categories', 'phila_news_category', 'Display news from these categories. This will override page category selection entirely.' ),
+        ),
+      ),
+    ),
+  );
+
+  $meta_boxes[] = array(
     'id'  => 'phila_call_to_action_multi',
     'title' => 'Call to action cards',
     'pages' => array( 'department_page' ),

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/meta-boxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/meta-boxes.php
@@ -941,6 +941,13 @@ $meta_boxes[] = array(
         'type' => 'checkbox',
         'after' => '<p class="description">Enter at least one staff member in the <a href="/wp-admin/edit.php?post_type=staff_directory">Staff Members</a> section.</p>',
       ),
+      array(
+        'id'  => 'phila_get_staff_cats',
+        'type' => 'group',
+        'fields' => array(
+          Phila_Gov_Standard_Metaboxes::phila_metabox_category_picker('Select new categories', 'phila_staff_category', 'Display staff members from these categories. This will override page category selection entirely.' ),
+        ),
+      ),
     ),
   );
 
@@ -969,6 +976,13 @@ $meta_boxes[] = array(
         'type' => 'checkbox',
         'after' => '<p class="description">Enter at least three press releases in the <a href="/wp-admin/edit.php?post_type=press_release">Press release</a> section.</p>'
       ),
+      array(
+        'id'  => 'phila_get_press_cats',
+        'type' => 'group',
+        'fields' => array(
+          Phila_Gov_Standard_Metaboxes::phila_metabox_category_picker('Select new categories', 'phila_press_release_category', 'Display press releases from these categories. This will override page category selection entirely.' ),
+        ),
+      ),
     ),
   );
 
@@ -996,6 +1010,13 @@ $meta_boxes[] = array(
         'desc'  => 'Should this page show a full row of blog posts?',
         'type' => 'checkbox',
         'after' => '<p class="description">Enter at least three blog posts in the <a href="/wp-admin/edit.php?post_type=phila_post">Blog Post</a> section.</p>'
+      ),
+      array(
+        'id'  => 'phila_get_blog_cats',
+        'type' => 'group',
+        'fields' => array(
+          Phila_Gov_Standard_Metaboxes::phila_metabox_category_picker('Select new categories', 'phila_blog_category', 'Display posts from these categories. This will override page category selection entirely.' ),
+        ),
       ),
     ),
   );

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/meta-boxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/meta-boxes.php
@@ -1012,10 +1012,10 @@ $meta_boxes[] = array(
         'after' => '<p class="description">Enter at least three blog posts in the <a href="/wp-admin/edit.php?post_type=phila_post">Blog Post</a> section.</p>'
       ),
       array(
-        'id'  => 'phila_get_blog_cats',
+        'id'  => 'phila_get_post_cats',
         'type' => 'group',
         'fields' => array(
-          Phila_Gov_Standard_Metaboxes::phila_metabox_category_picker('Select new categories', 'phila_blog_category', 'Display posts from these categories. This will override page category selection entirely.' ),
+          Phila_Gov_Standard_Metaboxes::phila_metabox_category_picker('Select new categories', 'phila_post_category', 'Display posts from these categories. This will override page category selection entirely.' ),
         ),
       ),
     ),

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/v2-departments.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/v2-departments.php
@@ -200,13 +200,21 @@ function phila_register_department_meta_boxes( $meta_boxes ){
 
 
   $meta_boxes[] = array(
-    'title' => 'Select categories',
+    'title' => 'Override page category selection',
     'pages'    => array( 'department_page' ),
     'visible' => array( 'phila_template_select', 'staff_directory_v2' ),
+    'context'  => 'normal',
+    'priority' => 'high',
 
     'fields' => array(
-      Phila_Gov_Standard_Metaboxes::phila_metabox_category_picker('Select categories', 'phila_staff_category', 'Display staff from these categories. This will override page category selection entirely.'),
-    )
+      array(
+        'id'  => 'phila_get_cats',
+        'type' => 'group',
+        'fields' => array(
+          Phila_Gov_Standard_Metaboxes::phila_metabox_category_picker('Select new categories', 'phila_staff_category', 'Display staff from these categories. This will override page category selection entirely.' ),
+        ),
+      ),
+    ),
   );
 
   $meta_boxes[] = array(

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/v2-departments.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/v2-departments.php
@@ -200,16 +200,12 @@ function phila_register_department_meta_boxes( $meta_boxes ){
 
 
   $meta_boxes[] = array(
-    'title' => 'Select category',
+    'title' => 'Select categories',
     'pages'    => array( 'department_page' ),
     'visible' => array( 'phila_template_select', 'staff_directory_v2' ),
 
     'fields' => array(
-      array(
-        'id' => 'phila_staff_category',
-        'name' => 'Get staff in this category only -- overrides page Category selection',
-        'type' => 'text',
-      )
+      Phila_Gov_Standard_Metaboxes::phila_metabox_category_picker('Select categories', 'phila_staff_category', 'Display staff from these categories. This will override page category selection entirely.'),
     )
   );
 

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/v2-departments.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/v2-departments.php
@@ -208,7 +208,7 @@ function phila_register_department_meta_boxes( $meta_boxes ){
 
     'fields' => array(
       array(
-        'id'  => 'phila_get_cats',
+        'id'  => 'phila_get_staff_cats',
         'type' => 'group',
         'fields' => array(
           Phila_Gov_Standard_Metaboxes::phila_metabox_category_picker('Select new categories', 'phila_staff_category', 'Display staff from these categories. This will override page category selection entirely.' ),

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/v2-departments.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/v2-departments.php
@@ -176,7 +176,6 @@ function phila_register_department_meta_boxes( $meta_boxes ){
         'sort_clone' => true,
 
         'fields' => array(
-          //TODO: decide whether or not we want to use arguments as demonstrated below
           Phila_Gov_Standard_Metaboxes::phila_metabox_title('Call to Action Title', 'phila_action_panel_cta_text_multi' ),
           Phila_Gov_Standard_Metaboxes::phila_metabox_textarea('Summary', 'phila_action_panel_summary_multi'),
           Phila_Gov_Standard_Metaboxes::phila_metabox_url('Link to Content','phila_action_panel_link_multi'),

--- a/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/news.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/news.php
@@ -36,9 +36,18 @@ function recent_news_shortcode($atts) {
    'posts' => 1,
     0 => 'list',
     'name' => 'News',
-    'category' => $category_slug,
+    'category' => '',
  ), $atts );
 
+
+  if ($a['category'] != ''){
+   $current_category = $a['category'];
+   $category_slug = get_category($a['category'])->slug;
+  } else {
+   $category = get_the_category();
+   $current_category = $category[0]->cat_ID;
+   $category_slug = $category[0]->slug;
+  }
 
    if ( ! is_flag( 'list', $atts ) ){
      if ( $a['posts'] > 4 || $a['posts'] == 2 ){
@@ -50,7 +59,7 @@ function recent_news_shortcode($atts) {
   'order'=> 'DESC',
   'orderby' => 'date',
   'post_type'  => 'news_post',
-  'category_name' => $a['category'],
+  'cat' => $current_category,
   );
 
   $news_loop = new WP_Query( $args );

--- a/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/press-releases.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/shortcodes/press-releases.php
@@ -15,10 +15,17 @@ function press_release_shortcode($atts) {
   $a = shortcode_atts( array(
    'posts' => 1,
    'name' => 'Press releases',
+    'category' => '',
   ), $atts );
 
-  $current_category = $category[0]->cat_ID;
-  $category_slug = $category[0]->slug;
+  if ($a['category'] != ''){
+    $current_category = $a['category'];
+    $category_slug = get_category($a['category'])->slug;
+  } else {
+    $category = get_the_category();
+    $current_category = $category[0]->cat_ID;
+    $category_slug = $category[0]->slug;
+  }
 
   $args = array( 'posts_per_page' => $a['posts'],
   'order'=> 'DESC',

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-staff-directory.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-staff-directory.php
@@ -9,7 +9,7 @@
 
 $user_selected_template = phila_get_selected_template();
 
-$category_override = rwmb_meta('phila_get_cats');
+$category_override = rwmb_meta('phila_get_staff_cats');
 
 if ( has_category() ):
   $categories = get_the_category();

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-staff-directory.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-staff-directory.php
@@ -9,20 +9,28 @@
 
 $user_selected_template = phila_get_selected_template();
 
-$category_override = rwmb_meta('phila_staff_category');
+$category_override = rwmb_meta('phila_get_cats');
 
 if ( has_category() ):
-
   $categories = get_the_category();
   $category_id = $categories[0]->cat_ID;
 
   if ( !empty( $category_override ) ) :
-    $category_id = $category_override;
+    phila_loop_clonable_metabox($category_override);
+    $category_id = implode(", ", $category_override['phila_staff_category']);
   endif;
+
 
   $staff_leadership_array = array();
   // The Staff Directory Loop
-  $args = array ( 'orderby' => 'title', 'order' => 'ASC', 'post_type' => 'staff_directory', 'cat' => $category_id, 'posts_per_page' => -1 );
+  $args = array(
+    'orderby' => 'title',
+    'order' => 'ASC',
+    'post_type' => 'staff_directory',
+    'cat' => array($category_id),
+    'posts_per_page' => -1
+  );
+
   $staff_member_loop = new WP_Query( $args );
 
   if ( $staff_member_loop->have_posts() ):

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-staff-directory.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-staff-directory.php
@@ -16,7 +16,6 @@ if ( has_category() ):
   $category_id = $categories[0]->cat_ID;
 
   if ( !empty( $category_override ) ) :
-    phila_loop_clonable_metabox($category_override);
     $category_id = implode(", ", $category_override['phila_staff_category']);
   endif;
 

--- a/wp/wp-content/themes/phila.gov-theme/templates/single-on-site-content.php
+++ b/wp/wp-content/themes/phila.gov-theme/templates/single-on-site-content.php
@@ -14,6 +14,7 @@
 <?php $full_width_press_releases = rwmb_meta( 'phila_full_row_press_releases_selected' ); ?>
 
 <?php $full_row_blog = rwmb_meta( 'phila_full_row_blog_selected' ); ?>
+<?php $full_row_news = rwmb_meta( 'phila_full_row_news_selected' ); ?>
 
 <?php $featured_meta = rwmb_meta( 'phila_v2_homepage_featured' ) ; ?>
 <?php $featured = phila_loop_clonable_metabox($featured_meta); ?>
@@ -69,8 +70,6 @@
 
     <?php get_template_part( 'partials/departments/content', 'row-one' ); ?>
 
-    <?php get_template_part( 'partials/departments/v2/content', 'homepage-full-width-cta'); ?>
-
     <?php if ( $full_row_blog ): ?>
       <?php
         $blog_cat_override = rwmb_meta('phila_get_post_cats');
@@ -87,11 +86,39 @@
       </section>
     <?php endif; ?>
 
+    <?php get_template_part( 'partials/departments/v2/content', 'homepage-full-width-cta'); ?>
+
+    <?php if ( $full_row_news ): ?>
+      <?php
+        $news_cat_override = rwmb_meta('phila_get_news_cats');
+
+        $categories = get_the_category();
+        $category_id = $categories[0]->cat_ID;
+
+        if ( !empty( $news_cat_override ) ) :
+          $category_id = implode(", ", $news_cat_override['phila_news_category']);
+        endif;
+        ?>
+      <section class="row">
+        <?php echo do_shortcode('[recent-news posts="3" category=" ' . $category_id .' "]'); ?>
+      </section>
+    <?php endif; ?>
+
     <?php get_template_part( 'partials/departments/content', 'row-two' ); ?>
 
     <?php if ( $full_width_press_releases ): ?>
+      <?php
+        $press_cat_override = rwmb_meta('phila_get_press_cats');
+
+        $categories = get_the_category();
+        $category_id = $categories[0]->cat_ID;
+
+        if ( !empty( $press_cat_override ) ) :
+          $category_id = implode(", ", $press_cat_override['phila_press_release_category']);
+        endif;
+        ?>
       <div class="row">
-        <?php echo do_shortcode('[press-releases posts=3]');?>
+        <?php echo do_shortcode('[press-releases posts=3 category="' . $category_id . '"]');?>
       </div>
     <?php endif; ?>
 

--- a/wp/wp-content/themes/phila.gov-theme/templates/single-on-site-content.php
+++ b/wp/wp-content/themes/phila.gov-theme/templates/single-on-site-content.php
@@ -72,8 +72,18 @@
     <?php get_template_part( 'partials/departments/v2/content', 'homepage-full-width-cta'); ?>
 
     <?php if ( $full_row_blog ): ?>
+      <?php
+        $blog_cat_override = rwmb_meta('phila_get_post_cats');
+
+        $categories = get_the_category();
+        $category_id = $categories[0]->cat_ID;
+
+        if ( !empty( $blog_cat_override ) ) :
+          $category_id = implode(", ", $blog_cat_override['phila_post_category']);
+        endif;
+        ?>
       <section class="row">
-        <?php echo do_shortcode('[recent-posts posts="3"]'); ?>
+        <?php echo do_shortcode('[recent-posts posts="3" category=" ' . $category_id .' "]'); ?>
       </section>
     <?php endif; ?>
 


### PR DESCRIPTION
* Creates ability to override or add more categories to blog, news, or press release displays. This means any department can pull in items from any other department, if they chose to. Especially useful for departments that oversee other departments. 
* Update metabox to 4.11.3