### PR TITLE
Rest api additions

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-custom-post-types.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-custom-post-types.php
@@ -96,7 +96,8 @@ class Phila_Gov_Custom_Post_Types{
           'editor',
           'page-attributes',
           'revisions',
-          'author'
+          'author',
+          'custom-fields'
         ),
         'public' => true,
         'show_in_rest' => true,

--- a/wp/wp-content/plugins/phila.gov-customization/admin/rest-addtions.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/rest-addtions.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * Exposes certain meta fields to the REST API.
+ * See https://developer.wordpress.org/rest-api/extending-the-rest-api/modifying-responses/
+ *
+*/
+
+/* Expose service page icons for use in Megamenu markup */
+add_action('rest_api_init', 'phila_register_icon_service_pages');
+
+function phila_register_icon_service_pages(){
+  $object_type = 'post';
+  $args = array(
+      'type'         => 'string',
+      'description'  => 'A meta key for service page icons. String.',
+      'single'       => true,
+      'show_in_rest' => true,
+  );
+  register_meta( $object_type, 'phila_page_icon', $args1 );
+}

--- a/wp/wp-content/plugins/phila.gov-customization/index.php
+++ b/wp/wp-content/plugins/phila.gov-customization/index.php
@@ -36,6 +36,7 @@ require $dir. '/admin/class-phila-gov-service-update-pages.php';
 require $dir. '/admin/class-phila-gov-site-wide-alert.php';
 require $dir. '/admin/class-phila-gov-staff-directory.php';
 require $dir. '/admin/define-roles.php';
+require $dir. '/admin/rest-addtions.php';
 require $dir. '/admin/tiny-mce.php';
 
 require $dir. '/admin/meta-boxes/class-phila-gov-admin-templates.php';


### PR DESCRIPTION
* Adds `phila_page_icon`, specifically in use on service pages to rest API. This will allow us to recreate the service mega menu. 