### PR TITLE
More explicit Content Security Policy

### DIFF
--- a/nginx/server.d/csp.conf
+++ b/nginx/server.d/csp.conf
@@ -1,2 +1,1 @@
-# From https://https.cio.gov/mixed-content/
-add_header Content-Security-Policy-Report-Only "default-src https: data: 'self' 'unsafe-inline' 'unsafe-eval'; report-uri {{REPORT_URI}}";
+add_header Content-Security-Policy "default-src 'self' 'unsafe-inline' 'unsafe-eval' *.phila.gov cdnjs.cloudflare.com cityofphiladelphia.github.io  *.doubleclick.net *.gstatic.com gstatic.com www.google-analytics.com *.googleapis.com translate.google.com www.google.com  www.googletagmanager.com code.ionicframework.com *.list-manage.com cdn.jotfor.ms *.jotformpro.com *.jotform.com *.jotform.io *.jotformpro.com api.swiftype.com data: https:; img-src * data:;";


### PR DESCRIPTION
This will remove  the Content Security Policy warning that appears on all pages.
```
The Content Security Policy 'default-src https: data: 'self' 'unsafe-inline' 'unsafe-eval'; report-uri' was delivered in report-only mode, but does not specify a 'report-uri'; the policy will have no effect. Please either add a 'report-uri' directive, or deliver the policy via the 'Content-Security-Policy' header.
``` 

* Allows images from all sources
* Essentially lists all urls from which we draw resources, including cdns. 
