### PR TITLE
Workflow

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -35,6 +35,11 @@ g/^upload_max_filesize/s/2/100
 w
 EOF
 
+if [ ! "$PHILA_TEST" ]; then
+echo 'Installing private plugins'
+"$_dir/private-plugins.sh"
+fi
+
 echo 'Reloading php-fpm'
 sudo service php7.0-fpm reload
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,6 +20,3 @@ if [ "$PHILA_TEST" ]; then
   $_dir/wp-config.sh
   $_dir/local-db.sh
 fi
-
-echo 'Installing private plugins'
-"$_dir/private-plugins.sh"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,8 +9,7 @@ sudo apt-get update
 echo "Allowing hq access"
 echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDde/ohFVNJyZgI3KXXt9uwipFNpu0oVFxZzeht/WAu9PRuiqOh9PUCHT+Ca/R1y70ltrO8OqGjOkmbmxBt99nvncxF8LPjQUG1rUePDOqOGNWs/d56rhLAsVM7cWXZG7xdLkJt8c5VrtXHsbRzaJ28RRwqT6C/x+ZPtx7POl/x1t8gNGeagAbbS3hq5O77ymHe4lukgcz4K5TuU8y36fH0Qp1Doe3exCDaN2DdBIz/OXYQru6vO5yRWvxMUTkxjh7GO1qsn0efWEfknrZekINNck/wP1hbvbP9xjwntyhOjxLAQrwYF6nH1iNY6J+hW/0qYrFdZqpC7dL+cmm+XVUH hq' >> ~/.ssh/authorized_keys
 
-echo "Install npm & command line utilities"
-sudo npm i -g browserify uglify-js postcss-cli autoprefixer
+echo "Install npm"
 cd /home/ubuntu/app/wp/wp-content/themes/phila.gov-theme
 sudo npm install
 cd /home/ubuntu/app


### PR DESCRIPTION
Move plugin code back to `deploy.sh`, but only run on production machines to save on dev deployment time. This means when a new dev machine is created, the `scripts/private-plugins.sh` script needs to be run in order for updates to private plugins to be installed. 

The global installs for CLI use of the following packages have been moved to the production AMI:
* browserify
* uglify-js
* postcss-cli
* autoprefixer