### PR TITLE
Until uglifyjs is swapped out, use var instead of const

### DIFF
--- a/wp/wp-content/themes/phila.gov-theme/js/dev/hashchange-check.js
+++ b/wp/wp-content/themes/phila.gov-theme/js/dev/hashchange-check.js
@@ -1,7 +1,7 @@
 function anchorOffset() {
   /* Account for sticky header when anchor links are present */
-  const $anchor = $(':target');
-  const fixedElementHeight = $('.sticky').outerHeight();
+  var $anchor = $(':target');
+  var fixedElementHeight = $('.sticky').outerHeight();
   if ($anchor.length > 0)
     window.scrollTo(0, $anchor.offset().top - fixedElementHeight);
 }


### PR DESCRIPTION
Eventually, we'll switch to [uglify-es](https://www.npmjs.com/package/uglify-es) or something similar. 