### PR TITLE
Correct action guide role display

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/js/admin-department-author.js
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/js/admin-department-author.js
@@ -109,6 +109,14 @@ jQuery(document).ready(function($){
       });
       $("#phila_template_select").val('post');
     }
+    if( !phila_WP_User.includes( 'secondary_action_guide_editor' ) ) {
+      $('#phila_template_select option').each( function () {
+        if( $(this).val() !== '' && $(this).val() == 'action_guide' ){
+          $(this).css('display', 'none');
+        }
+      });
+    }
+
   }
 
 });

--- a/wp/wp-content/plugins/phila.gov-customization/admin/js/admin.js
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/js/admin.js
@@ -148,14 +148,6 @@ jQuery(document).ready(function($) {
       maxlength: 116
     });
 
-    if( !phila_WP_User.includes('administrator') && !phila_WP_User.includes('editor') && !phila_WP_User.includes('secondary_action_guide_editor')) {
-      $('#phila_template_select option').each( function () {
-        if( $(this).val() !== '' && $(this).val() !== 'action_guide' ){
-          $(this).css('display', 'none');
-        }
-      });
-    }
-
   }
 
 });


### PR DESCRIPTION
* Ensure users who aren't admins or editors don't see action guides without explicit permission