### PR TITLE
Correct meta desc

### DIFF
--- a/wp/wp-content/themes/phila.gov-theme/functions.php
+++ b/wp/wp-content/themes/phila.gov-theme/functions.php
@@ -237,12 +237,10 @@ function phila_open_graph() {
 
   $link = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 
-  $blog_info = get_bloginfo('description');
-
   //TODO: Determine which twitter account should be used for site attribution ?>
   <meta name="twitter:card" content="summary">
   <meta property="og:title" content="<?php echo str_replace(' | ' . get_bloginfo('name'), '', phila_filter_title( $title ) )?>"/>
-  <meta property="og:description" content="<?php echo ( is_archive() || is_search() || is_home() ) ? $blog_info : phila_get_item_meta_desc(); ?>"/>
+  <meta property="og:description" content="<?php echo ( is_archive() || is_search() || is_home() ) ? get_bloginfo('description'): phila_get_item_meta_desc(); ?>"/>
   <meta property="og:type" content="<?php echo isset($type) ? $type : 'website' ?>"/>
   <meta property="og:url" content="<?php echo $link ?>"/>
   <meta property="og:site_name" content="<?php echo get_bloginfo(); ?>"/>
@@ -977,6 +975,8 @@ function phila_get_item_meta_desc( $bloginfo = true ){
   $page_desc = rwmb_meta( 'phila_page_desc' );
 
   $canonical_meta_desc = rwmb_meta( 'phila_meta_desc' );
+
+  $blog_info = get_bloginfo('description');
 
   //This order matters. If $canonical_meta_desc is found first, it should be used.
   array_push($meta_desc, $canonical_meta_desc, $page_desc, $document_desc, $news_desc, $post_desc, $dept_desc);

--- a/wp/wp-content/themes/phila.gov-theme/functions.php
+++ b/wp/wp-content/themes/phila.gov-theme/functions.php
@@ -235,15 +235,14 @@ function phila_open_graph() {
     $type = 'article';
   }
 
-
-
   $link = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 
-  //TODO: Determine which twitter account should be used for site attribution
-  ?>
+  $blog_info = get_bloginfo('description');
+
+  //TODO: Determine which twitter account should be used for site attribution ?>
   <meta name="twitter:card" content="summary">
   <meta property="og:title" content="<?php echo str_replace(' | ' . get_bloginfo('name'), '', phila_filter_title( $title ) )?>"/>
-  <meta property="og:description" content="<?php echo str_replace('"',  '&quot;', phila_get_item_meta_desc()); ?>"/>
+  <meta property="og:description" content="<?php echo ( is_archive() || is_search() || is_home() ) ? $blog_info : phila_get_item_meta_desc(); ?>"/>
   <meta property="og:type" content="<?php echo isset($type) ? $type : 'website' ?>"/>
   <meta property="og:url" content="<?php echo $link ?>"/>
   <meta property="og:site_name" content="<?php echo get_bloginfo(); ?>"/>
@@ -979,22 +978,14 @@ function phila_get_item_meta_desc( $bloginfo = true ){
 
   $canonical_meta_desc = rwmb_meta( 'phila_meta_desc' );
 
-  if( is_archive() || is_search() || is_home() ) {
-    if ($bloginfo) {
-      return bloginfo( 'description' );
-    }
-  }
-
   //This order matters. If $canonical_meta_desc is found first, it should be used.
   array_push($meta_desc, $canonical_meta_desc, $page_desc, $document_desc, $news_desc, $post_desc, $dept_desc);
 
-
   foreach ($meta_desc as $desc){
     if ( !empty( $desc ) ) {
-      return wp_strip_all_tags($desc);
+      return str_replace('"',  '&quot;', ( wp_strip_all_tags( $desc ) ) );
     }
   }
-
 
   if ( get_post_type() == 'department_page' ) {
 
@@ -1034,13 +1025,13 @@ function phila_get_item_meta_desc( $bloginfo = true ){
 
     }else{
       if ($bloginfo) {
-        return bloginfo( 'description' );
+        return $blog_info;
       }
     }
 
   }else{
     if ($bloginfo) {
-      return bloginfo( 'description' );
+      return $blog_info;
     }
   }
 }

--- a/wp/wp-content/themes/phila.gov-theme/header.php
+++ b/wp/wp-content/themes/phila.gov-theme/header.php
@@ -6,12 +6,13 @@
  *
  * @package phila-gov
  */
+
 ?><!DOCTYPE html>
 <html <?php language_attributes(); ?> class="no-js">
 <head>
   <meta charset="<?php bloginfo( 'charset' ); ?>">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <meta name="description" content="<?php echo phila_get_item_meta_desc( ); ?>">
+  <meta name="description" content="<?php echo ( is_archive() || is_search() || is_home() ) ? get_bloginfo('description') : phila_get_item_meta_desc(); ?>">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#2176d2">
 


### PR DESCRIPTION
* Move check for post type out of `phila_get_item_meta_desc()` to prevent duplication of meta descriptions on pages with lists of meta descriptions. 