### PR TITLE
staff template note

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-admin-templates.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-admin-templates.php
@@ -88,7 +88,7 @@ class Phila_Gov_Admin_Templates {
       array(
         'id' => 'phila_template_select_staff',
         'type' => 'custom_html',
-        'std' => '<a href="/wp-admin/edit.php?post_type=staff_directory">Click here</a> to add/edit staff members.',
+        'std' => 'Visit <a href="/wp-admin/edit.php?post_type=staff_directory">staff members</a> section to add/edit staff.',
         'visible' => array('phila_template_select', 'in', ['staff_directory_v2','staff_directory'])
       )
     ),

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-admin-templates.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-admin-templates.php
@@ -85,6 +85,12 @@ class Phila_Gov_Admin_Templates {
           'relation' => 'or'
         ),
       ),
+      array(
+        'id' => 'phila_template_select_staff',
+        'type' => 'custom_html',
+        'std' => '<a href="/wp-admin/edit.php?post_type=staff_directory">Click here</a> to add/edit staff members.',
+        'visible' => array('phila_template_select', 'in', ['staff_directory_v2','staff_directory'])
+      )
     ),
   );
    return $meta_boxes;


### PR DESCRIPTION
Trello issue: When "Staff" template is selected, add note about where in the admin to add new staff members.

The message is applied to the new and old staff directory template.

Moved this fix to its own branch.
