### PR TITLE
Fixes

### DIFF
--- a/wp/wp-content/themes/phila.gov-theme/css/scss/modules/_hero-half.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/modules/_hero-half.scss
@@ -19,7 +19,9 @@
     font-size: 1.6rem;
   }
   .hero-image{
-    position: relative;
+    background-size: cover;
+    background-repeat: no-repeat;
+    min-height: 400px;
   }
   .photo-credit {
     display:none;

--- a/wp/wp-content/themes/phila.gov-theme/functions.php
+++ b/wp/wp-content/themes/phila.gov-theme/functions.php
@@ -538,7 +538,7 @@ function phila_get_attachment_id_by_url( $url ) {
   //Filter out everything before /media/ because we are matching on the aws url and not what is in wp-content
   preg_match('/\/media\/(.+)/', $url, $matches);
 
-  $parsed_url = $matches[1];
+  $parsed_url = urldecode($matches[1]);
 
   $attachment = $wpdb->get_col($wpdb->prepare("SELECT post_id FROM $wpdb->postmeta WHERE meta_key = 'amazonS3_info' AND meta_value LIKE %s;", '%"' .'media/' .$parsed_url .'"%' ));
 

--- a/wp/wp-content/themes/phila.gov-theme/partials/programs/header.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/programs/header.php
@@ -34,7 +34,7 @@
   <?php else: ?>
     <div class="hero-half">
       <div class="grid-x">
-        <div class="cell large-12 bg-shade bg-ben-franklin-blue white hero-half--container">
+        <div class="cell medium-12 bg-shade bg-ben-franklin-blue white hero-half--container">
           <div class="grid-x grid-container align-right">
             <div class="hero-half--title mvm">
               <h1><?php echo the_title() ?></h1>
@@ -42,8 +42,7 @@
             </div>
           </div>
         </div>
-        <div class="cell large-12 align-self-stretch hero-image">
-          <img src="<?php echo $hero['full_url'] ?>" alt="" class="show-for-large">
+        <div class="cell medium-12 align-self-stretch hero-image hide-for-small-only" style="background-image:url(<?php echo $hero['full_url']  ?>) ">
           <?php echo !empty($credit) ? '<div class="photo-credit">' . $credit . '</div>' : '' ?>
         </div>
       </div>


### PR DESCRIPTION
Two corrections:
* Matches file URL that could be uploaded with special characters to the way the value is saved in the database. 
* Hero-half templates are now using background images instead, to allow the text to determine a height larger than 400px, if necessary. 