### PR TITLE
Document landing

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/public/class-phila-document-controller.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/class-phila-document-controller.php
@@ -54,7 +54,6 @@ class Phila_Publications_Controller {
       'order' => 'desc',
       'orderby' => 'date',
     );
-
     if ( isset( $request['start_date'] ) && isset( $request['end_date'] ) ){
       $date_query = array(
         'date_query' => array(
@@ -68,7 +67,40 @@ class Phila_Publications_Controller {
       $args = array_merge($args, $date_query);
     }
 
-    $posts = get_posts( $args );
+    $department_pages = array(
+      'post_type' => array('department_page'),
+      'posts_per_page'  => -1,
+      'meta_query' => array(
+        array(
+          'key'     => 'phila_template_select',
+          'value'   => 'document_finder_v2',
+          'compare' => '=',
+        ),
+      ),
+      'category'  => array($request['category']),
+      's' => $request['s'],
+      'order' => 'desc',
+      'orderby' => 'date',
+    );
+
+    if ( isset( $request['start_date'] ) && isset( $request['end_date'] ) ){
+      $date_query = array(
+        'date_query' => array(
+          array(
+            'after'     => $request['start_date'],
+            'before'    => $request['end_date']
+            ),
+            'inclusive' => true,
+          ),
+        );
+      $department_pages = array_merge($department_pages, $date_query);
+    }
+
+    $docs = get_posts( $args );
+
+    $department_site = get_posts($department_pages);
+
+    $posts = array_merge( $docs, $department_site );
 
     $data = array();
 

--- a/wp/wp-content/themes/phila.gov-theme/css/scss/_table.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/_table.scss
@@ -1,39 +1,48 @@
 /* searchable, sortable document table */
 
-.document-table{
-  .table-sort{
-    position: relative;
-    cursor: pointer;
-    color: white;
-    padding-right: 2rem;
+.table-sort{
+  position: relative;
+  cursor: pointer;
+  color: white;
+  padding-right: 2rem;
 
-    span::after{
-      position: absolute;
-      display: inline;
-      content: '';
-      margin: auto 10px auto;
-      width: 0;
-      height: 0;
-      border: inset 5px;
-      border-color: white transparent transparent;
-      border-top-style: solid;
-      border-bottom-width: 0;
-      float: none;
-      top: 0;
-      bottom: 0;
-      height: 10px;
-    }
+  span::after{
+    position: absolute;
+    display: inline;
+    content: '';
+    margin: auto 10px auto;
+    width: 0;
+    height: 0;
+    border: inset 5px;
+    border-color: white transparent transparent;
+    border-top-style: solid;
+    border-bottom-width: 0;
+    float: none;
+    top: 0;
+    bottom: 0;
+    height: 10px;
   }
-  .table-sort.asc {
-    span::after{
-      border-color: transparent transparent white;
-      border-bottom-style: solid;
-      border-bottom-width: 5px;
-    }
+}
+.table-sort.asc {
+  span::after{
+    border-color: transparent transparent white;
+    border-bottom-style: solid;
+    border-bottom-width: 5px;
   }
 }
 
+
 table.theme-light{
+  .table-sort {
+    span::after{
+      border-color: color(dark-gray) transparent transparent;
+    }
+    &.asc{
+      span::after{
+        border-color: transparent transparent color(dark-gray);
+      }
+    }
+  }
   thead{
     border-bottom:5px solid color(dark-gray);
     background: white;
@@ -84,7 +93,7 @@ table.theme-light{
       width:500px;
     }
     .date{
-      width:125px;
+      width:150px;
     }
   }
 }

--- a/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Publications.vue
+++ b/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Publications.vue
@@ -35,6 +35,7 @@
             <v-select
             label="slang_name"
             placeholder="All departments"
+            v-model="selected"
             :options="categories"
             :on-change="filterByCategory">
             </v-select>
@@ -117,6 +118,7 @@ export default {
 
       currentSort:'date',
       currentSortDir:'desc',
+      selected: null,
 
       selectedCategory: '',
 
@@ -205,7 +207,8 @@ export default {
       this.searchedVal = ''
       this.state.startDate = ''
       this.state.endDate = ''
-      this.selectedCategory = ''
+      //a little convoluted, but will change the state of selected if the reset button is used mutiple times in a session
+      this.selected = (this.selected == null ? '' : null)
       this.runDateQuery()
       this.filterByCategory()
 

--- a/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Publications.vue
+++ b/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Publications.vue
@@ -54,9 +54,13 @@
     <table class="stack theme-light archive-results"  data-sticky-container v-show="!loading && !emptyResponse && !failure">
       <thead class="sticky center bg-white" data-sticky data-top-anchor="filter-results:bottom" data-btm-anchor="page:bottom" data-options="marginTop:4.8;">
         <tr>
-          <th class="title" @click="sort('title')">Title</th>
-          <th class="date" @click="sort('date')">Publish date</th>
-          <th class="department" @click="sort('department')">Department</th>
+          <th class="table-sort title"
+          @click="sort('title')" v-bind:class="sortTitle"><span>Title</span></th>
+
+          <th class="table-sort date"
+          @click="sort('date')"
+          v-bind:class="sortDate"><span>Publish date</span></th>
+          <th class="department">Department</th>
         </tr>
       </thead>
       <paginate name="documents"
@@ -118,6 +122,7 @@ export default {
 
       currentSort:'date',
       currentSortDir:'desc',
+
       selected: null,
 
       selectedCategory: '',
@@ -266,12 +271,13 @@ export default {
           this.loading = false
       })
     },
-    sort: function( s ) {
-      //if s == current sort, reverse
-     if(s === this.currentSort) {
-       this.currentSortDir = this.currentSortDir==='asc'?'desc':'asc';
-     }
-     this.currentSort = s;
+    sort: function( column ) {
+      console.log( column )
+      //if column == current sort, reverse
+      if(column === this.currentSort) {
+        this.currentSortDir = this.currentSortDir === 'asc' ? 'desc' : 'asc';
+      }
+      this.currentSort = column;
    },
    filteredList: function ( list, searchedVal ) {
      let searched = this.searchedVal.trim()
@@ -281,6 +287,17 @@ export default {
    },
   },
   computed:{
+    sortTitle: function(clicked){
+      if (this.currentSort == 'title') {
+        return this.currentSortDir
+      }
+    },
+    sortDate: function(){
+      if (this.currentSort == 'date'){
+        return this.currentSortDir
+      }
+
+    },
     successfulResponse: function(){
       if (this.documents.length == 0) {
         this.emptyResponse = true

--- a/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Publications.vue
+++ b/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Publications.vue
@@ -1,8 +1,8 @@
 <template>
   <div id="publications">
-    <form v-on:submit.prevent="onSubmit">
+    <form v-on:submit.prevent>
       <div class="search">
-        <input id="post-search" type="text" name="search" placeholder="Search by title" class="search-field" ref="search-field"
+        <input id="post-search" type="text" name="search" placeholder="Begin typing to filter by title" class="search-field" ref="search-field"
         v-model="searchedVal">
         <input type="submit" value="submit" class="search-submit">
       </div>
@@ -16,7 +16,7 @@
             placeholder="Start date"
             v-on:closed="runDateQuery"
             v-model="state.startDate"
-            format="MMM. dd, yyyy"
+            format="MMM. dd, yyyy"z
             :disabled="state.disabled"></datepicker>
           </div>
           <div class="cell medium-1 small-2 mts">
@@ -56,7 +56,7 @@
         <tr>
           <th class="title" @click="sort('title')">Title</th>
           <th class="date" @click="sort('date')">Publish date</th>
-          <th @click="sort('department')">Department</th>
+          <th class="department" @click="sort('department')">Department</th>
         </tr>
       </thead>
       <paginate name="documents"
@@ -185,29 +185,6 @@ export default {
     },
     goToDoc: function (link){
       window.location.href = link
-     },
-    onSubmit: function (event) {
-      this.loading = true
-
-      this.$nextTick(function () {
-        axios.get(pubsEndpoint + 'archives', {
-          params : {
-            's': this.searchedVal,
-            'category': this.selectedCategory,
-            'count': -1,
-            'start_date': this.state.startDate,
-            'end_date': this.state.endDate,
-            }
-          })
-          .then(response => {
-            this.documents = response.data
-            this.successfulResponse
-          })
-          .catch(e => {
-            this.failure = true
-            this.loading = false
-        })
-      })
     },
     reset() {
       //this.loading = true
@@ -295,7 +272,13 @@ export default {
        this.currentSortDir = this.currentSortDir==='asc'?'desc':'asc';
      }
      this.currentSort = s;
-   }
+   },
+   filteredList: function ( list, searchedVal ) {
+     let searched = this.searchedVal.trim()
+     return list.filter((document) => {
+        return document.title.toLowerCase().indexOf(searched.toLowerCase()) > -1
+     })
+   },
   },
   computed:{
     successfulResponse: function(){
@@ -310,13 +293,13 @@ export default {
       }
     },
     sortedDocuments:function() {
-      return this.documents.sort((a,b) => {
+      return this.filteredList(this.documents.sort((a,b) => {
         let modifier = 1;
         if(this.currentSortDir === 'desc') modifier = -1;
         if(a[this.currentSort] < b[this.currentSort]) return -1 * modifier;
         if(a[this.currentSort] > b[this.currentSort]) return 1 * modifier;
         return 0;
-      });
+      }), this.searchedVal)
     }
   }
 

--- a/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Publications.vue
+++ b/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Publications.vue
@@ -53,10 +53,14 @@
 
     <table class="stack theme-light archive-results"  data-sticky-container v-show="!loading && !emptyResponse && !failure">
       <thead class="sticky center bg-white" data-sticky data-top-anchor="filter-results:bottom" data-btm-anchor="page:bottom" data-options="marginTop:4.8;">
-        <tr><th class="title">Title</th><th class="date">Publish date</th><th>Department</th></tr>
+        <tr>
+          <th class="title" @click="sort('title')">Title</th>
+          <th class="date" @click="sort('date')">Publish date</th>
+          <th @click="sort('department')">Department</th>
+        </tr>
       </thead>
       <paginate name="documents"
-        :list="documents"
+        :list="sortedDocuments"
         class="paginate-list"
         tag="tbody"
         :per="40">
@@ -78,6 +82,7 @@
         </tr>
       </paginate>
     </table>
+    debug: sort={{currentSort}}, dir={{currentSortDir}}
     <paginate-links for="documents"
     :limit="3"
     :show-step-links="true"
@@ -110,6 +115,9 @@ export default {
     return{
       documents: [],
       categories: [{ }],
+
+      currentSort:'date',
+      currentSortDir:'desc',
 
       selectedCategory: '',
 
@@ -281,6 +289,13 @@ export default {
         })
       })
     },
+    sort: function( s ) {
+      //if s == current sort, reverse
+     if(s === this.currentSort) {
+       this.currentSortDir = this.currentSortDir==='asc'?'desc':'asc';
+     }
+     this.currentSort = s;
+   }
   },
   computed:{
     successfulResponse: function(){
@@ -294,7 +309,16 @@ export default {
         this.failure = false
       }
     },
-  },
+    sortedDocuments:function() {
+      return this.documents.sort((a,b) => {
+        let modifier = 1;
+        if(this.currentSortDir === 'desc') modifier = -1;
+        if(a[this.currentSort] < b[this.currentSort]) return -1 * modifier;
+        if(a[this.currentSort] > b[this.currentSort]) return 1 * modifier;
+        return 0;
+      });
+    }
+  }
 
 }
 </script>

--- a/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Publications.vue
+++ b/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Publications.vue
@@ -16,7 +16,7 @@
             placeholder="Start date"
             v-on:closed="runDateQuery"
             v-model="state.startDate"
-            format="MMM. dd, yyyy"z
+            format="MMM. dd, yyyy"
             :disabled="state.disabled"></datepicker>
           </div>
           <div class="cell medium-1 small-2 mts">
@@ -86,6 +86,7 @@
     <paginate-links for="documents"
     :limit="3"
     :show-step-links="true"
+    :hide-single-page="true"
     :step-links="{
       next: 'Next',
       prev: 'Previous'
@@ -151,9 +152,26 @@ export default {
     }
   },
   mounted: function () {
-    this.getAllDocs()
+    //this.getAllDocs()
     this.getDropdownCategories()
     this.loading = true
+  },
+  created: function(){
+    this.loading = true
+
+    axios.get(pubsEndpoint + 'archives', {
+      params: {
+        'count': -1,
+      }
+    })
+    .then(response => {
+      this.documents = response.data
+      this.successfulResponse
+    })
+    .catch(e => {
+      this.failure = true
+      this.loading = false
+    })
   },
   methods: {
     getAllDocs: function () {
@@ -187,30 +205,13 @@ export default {
       window.location.href = link
     },
     reset() {
-      //this.loading = true
-      //console.log(this.$refs.categorySelect)
-      //console.log(this.$refs.categorySelect.$el.textContent)
-      window.location = window.location.pathname;
-      /*this.selectedCategory = ''
-      axios.get(pubsEndpoint + 'archives', {
-       params : {
-          'count': -1
-        }
-      })
-        .then(response => {
-          this.documents = response.data
-          this.loading = false
-          this.searchedVal = ''
-          this.checkedTemplates = ''
-          this.selectedCategory = ''
-          this.state.startDate = ''
-          this.state.endDate = ''
-        })
-        .catch(e => {
-          this.failure = true
-      })
-      this.$forceUpdate();
-      */
+      console.log('Reseting the form')
+      var self = this; //you need this because *this* will refer to Object.keys below`
+
+      this.searchedVal = ''
+      this.state.startDate = ''
+      this.state.endDate = ''
+
     },
     runDateQuery(){
       if ( !this.state.startDate || !this.state.endDate )

--- a/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Publications.vue
+++ b/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Publications.vue
@@ -155,7 +155,6 @@ export default {
     }
   },
   mounted: function () {
-    //this.getAllDocs()
     this.getDropdownCategories()
     this.loading = true
   },
@@ -177,24 +176,6 @@ export default {
     })
   },
   methods: {
-    getAllDocs: function () {
-      this.loading = true
-
-      axios.get(pubsEndpoint + 'archives', {
-        params: {
-          'count': -1,
-        }
-      })
-      .then(response => {
-        this.documents = response.data
-        this.successfulResponse
-      })
-      .catch(e => {
-        this.failure = true
-        this.loading = false
-      })
-
-    },
     getDropdownCategories: function () {
       axios.get('/wp-json/the-latest/v1/categories')
       .then(response => {

--- a/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Publications.vue
+++ b/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Publications.vue
@@ -33,7 +33,6 @@
           </div>
           <div class="cell medium-9 small-24 auto filter-by-owner">
             <v-select
-            ref="categorySelect"
             label="slang_name"
             placeholder="All departments"
             :options="categories"
@@ -82,7 +81,6 @@
         </tr>
       </paginate>
     </table>
-    debug: sort={{currentSort}}, dir={{currentSortDir}}
     <paginate-links for="documents"
     :limit="3"
     :show-step-links="true"
@@ -139,8 +137,6 @@ export default {
           from: new Date()
         }
       },
-
-      //queriedCategory: this.$route.query.category
 
     }
   },
@@ -205,12 +201,13 @@ export default {
       window.location.href = link
     },
     reset() {
-      console.log('Reseting the form')
-      var self = this; //you need this because *this* will refer to Object.keys below`
 
       this.searchedVal = ''
       this.state.startDate = ''
       this.state.endDate = ''
+      this.selectedCategory = ''
+      this.runDateQuery()
+      this.filterByCategory()
 
     },
     runDateQuery(){
@@ -238,33 +235,32 @@ export default {
       })
     },
     filterByCategory: function(selectedVal){
-      this.selectedCategory = selectedVal
+      if (selectedVal == null){
+        this.selectedCategory = ''
+      }else{
+        this.selectedCategory = selectedVal.id
+      }
 
-      this.$nextTick(function () {
+      this.loading = true
 
-        this.loading = true
-
-        axios.get(pubsEndpoint + 'archives', {
-          params : {
-            's': this.searchedVal,
-            'category': this.selectedCategory.id,
-            'count' : -1,
-            'start_date': this.state.startDate,
-            'end_date': this.state.endDate,
-            }
-          })
-          .then(response => {
-            this.loading = false
-            //Don't let empty value change the rendered view
-            if ( 'id' in selectedVal ){
-              this.documents = response.data
-            }
-            this.successfulResponse
-          })
-          .catch(e => {
-            this.failure = true
-            this.loading = false
+      axios.get(pubsEndpoint + 'archives', {
+        params : {
+          's': this.searchedVal,
+          'category': this.selectedCategory,
+          'count' : -1,
+          'start_date': this.state.startDate,
+          'end_date': this.state.endDate,
+          }
         })
+        .then(response => {
+          this.loading = false
+          this.documents = response.data
+
+          this.successfulResponse
+        })
+        .catch(e => {
+          this.failure = true
+          this.loading = false
       })
     },
     sort: function( s ) {
@@ -301,7 +297,7 @@ export default {
         if(a[this.currentSort] > b[this.currentSort]) return 1 * modifier;
         return 0;
       }), this.searchedVal)
-    }
+    },
   }
 
 }

--- a/wp/wp-content/themes/phila.gov-theme/package-lock.json
+++ b/wp/wp-content/themes/phila.gov-theme/package-lock.json
@@ -177,7 +177,7 @@
         "caniuse-lite": "1.0.30000810",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
-        "postcss": "6.0.20",
+        "postcss": "6.0.21",
         "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
@@ -3532,9 +3532,9 @@
       }
     },
     "postcss": {
-      "version": "6.0.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
-      "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
+      "version": "6.0.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+      "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.2",

--- a/wp/wp-content/themes/phila.gov-theme/package.json
+++ b/wp/wp-content/themes/phila.gov-theme/package.json
@@ -41,7 +41,7 @@
     "browserify-shim": "^3.8.14",
     "envify": "^4.1.0",
     "node-sass": "^4.8.3",
-    "postcss": "^6.0.20",
+    "postcss": "^6.0.21",
     "vueify": "^9.4.0"
   },
   "dependencies": {


### PR DESCRIPTION
* Adds department pages with the document finder template to documents and forms search.
* Cleans up implementation to add sort by date, and filters existing list instead of forcing new API call.
* Corrects "reset" to actually reset the data.
* Adds sortable table headers.