### PR TITLE
Program menus

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-admin-menu.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-admin-menu.php
@@ -72,8 +72,10 @@ class Phila_Gov_Admin_Menu {
 
   function change_admin_post_label(){
 
-    // Add Menus as a Department Site submenu
+    // Add Menus as a Department Site submenu and program pages
     add_submenu_page( 'edit.php?post_type=department_page', 'Nav Menu', 'Nav Menu', 'edit_posts', 'nav-menus.php');
+    add_submenu_page( 'edit.php?post_type=programs', 'Nav Menu', 'Nav Menu', 'edit_posts', 'nav-menus.php');
+
 
     remove_menu_page( 'edit.php?post_type=announcement' );
 

--- a/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-admin-menu.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-admin-menu.php
@@ -74,8 +74,8 @@ class Phila_Gov_Admin_Menu {
 
     // Add Menus as a Department Site submenu and program pages
     add_submenu_page( 'edit.php?post_type=department_page', 'Nav Menu', 'Nav Menu', 'edit_posts', 'nav-menus.php');
+    
     add_submenu_page( 'edit.php?post_type=programs', 'Nav Menu', 'Nav Menu', 'edit_posts', 'nav-menus.php');
-
 
     remove_menu_page( 'edit.php?post_type=announcement' );
 

--- a/wp/wp-content/themes/phila.gov-theme/css/scss/_programs-initiatives.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/_programs-initiatives.scss
@@ -61,3 +61,80 @@
   background-repeat: no-repeat;
   background-size: cover;
 }
+
+.program #site-nav {
+  text-align: left;
+  @include breakpoint(medium up) {
+    margin-bottom:0;
+    margin-top:-15px;
+    text-align: center;
+    .menu{
+      display: inline-block;
+    }
+    .secondary-menu {
+      border: 3px solid white;
+      background: white;
+
+      .dropdown li{
+        border-bottom:2px solid white;
+        &:last-child{
+          border-bottom:2px solid white;
+        }
+      }
+      >li {
+        display: inline-block;
+        background-color: color(ben-franklin-blue);
+        &.opens-right{
+          >a {
+            padding: $spacing-small $spacing-large;
+          }
+          > a::after{
+            display: inline;
+            margin: auto 0;
+            left: 5px;
+            position: relative;
+            float: none;
+            top: 10px;
+            bottom: 0;
+          }
+          &.is-active,
+          &.current-menu-ancestor{
+            > a{
+              background: color(dark-gray);
+              color:white;
+            }
+          }
+        }
+        >a {
+          color: white;
+          padding: $spacing-small $spacing-medium;
+        }
+      }
+      a {
+        border:none;
+        &:hover, &:active {
+          background: color(dark-gray);
+          color:white;
+        }
+      }
+      .is-dropdown-submenu {
+        top: auto;
+        left:0;
+        a{
+          background: color(ghost-gray);
+          color:color(ben-franklin-blue);
+          &:hover, &:active {
+            background: color(dark-gray);
+            color:white;
+          }
+        }
+      }
+      .current-menu-item {
+        > a{
+          background: color(dark-gray);
+          color:white;
+        }
+      }
+    }
+  }
+}

--- a/wp/wp-content/themes/phila.gov-theme/functions.php
+++ b/wp/wp-content/themes/phila.gov-theme/functions.php
@@ -436,7 +436,7 @@ function phila_get_thumbnails(){
   }
 }
 
-function phila_get_department_menu() {
+function phila_get_menu() {
   /*
     Set the menus. Menus are created when a page is registered with a homepage template. Look for the furthest ancestor, get its ID and if there is a menu registered, display it.
   */

--- a/wp/wp-content/themes/phila.gov-theme/functions.php
+++ b/wp/wp-content/themes/phila.gov-theme/functions.php
@@ -458,9 +458,9 @@ function phila_get_menu() {
       'before'          => '',
       'after'           => '',
       'items_wrap'      => '
-      <div class="row">
+      <div class="row center">
         <div class="small-24 columns">
-          <div class="mbm-mu" id="site-nav">
+          <div id="site-nav">
             <nav data-swiftype-index="false">
               <ul id="%1$s" class="%2$s" data-responsive-menu="accordion medium-dropdown">%3$s</ul>
               </nav>

--- a/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Programs.vue
+++ b/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Programs.vue
@@ -58,7 +58,7 @@
           <div v-show="failure" class="h3 mtm center">Sorry, there was a problem. Please try again.</div>
           <div class="grid-x grid-margin-x grid-padding-x program-archive-results" v-show="!loading && !emptyResponse && !failure"></div>
         </div>
-        <div id="program-results" class="grid-x grid-margin-x grid-padding-x">
+        <div id="program-results" class="grid-x grid-margin-x">
           <div v-for="program in programs"
           :key="program.id"
           class="medium-12 cell mbl">

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/v2/department-hero.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/v2/department-hero.php
@@ -42,7 +42,7 @@
                   */
                     //TODO: clean up menu rendering
                     //
-                    phila_get_department_menu();
+                    phila_get_menu();
                 ?>
 
             </div> <!-- END .hero-wrap  -->

--- a/wp/wp-content/themes/phila.gov-theme/partials/programs/header.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/programs/header.php
@@ -56,4 +56,5 @@
         </div>
       </div>
   <?php endif; ?>
+  <?php phila_get_menu(); ?>
 </header>

--- a/wp/wp-content/themes/phila.gov-theme/single-department_page.php
+++ b/wp/wp-content/themes/phila.gov-theme/single-department_page.php
@@ -82,7 +82,7 @@ get_header(); ?>
           This checks to make sure a category exists for the given page,
           if it does, we render our menu w/ markup.
           */
-            phila_get_department_menu();
+            phila_get_menu();
         }
         ?>
       <?php endif; ?>


### PR DESCRIPTION
Adds ability for admins to add menus to any item with a "homepage" template. Dismantles old system of category association and instead registers all homepage templates as a discrete menu location, allowing for more flexibility for future menus and especially while pages are being staged for changes. 