### PR TITLE
Site wide alert fixings

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/public/class-phila-gov-site-wide-alert-rendering.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/class-phila-gov-site-wide-alert-rendering.php
@@ -5,16 +5,6 @@ if ( class_exists( "Phila_Gov_Site_Wide_Alert_Rendering" ) ){
 
 class Phila_Gov_Site_Wide_Alert_Rendering {
   /**
-   * Set the session when the alert is closed. 
-   */
-  static function alert_closed_session() {
-    if ( isset( $_POST['id_alert'] ) && is_numeric( $_POST['id_alert'] ) ) {
-      setcookie( "closed-alert-{$_POST['id_alert']}", 1, 0, '/' );
-    }
-    wp_die("Done!");
-  }
-
-  /**
   * TODO: set cookie when button is closed, remember until alert is updated
   * Display alert if display is true, also show on preview
   *

--- a/wp/wp-content/plugins/phila.gov-customization/public/class-phila-gov-site-wide-alert-rendering.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/class-phila-gov-site-wide-alert-rendering.php
@@ -4,26 +4,12 @@ if ( class_exists( "Phila_Gov_Site_Wide_Alert_Rendering" ) ){
 }
 
 class Phila_Gov_Site_Wide_Alert_Rendering {
-
-  /** 
-   * Create the ajax actions to set a session when the alert is closed. 
-   */ 
-  public static function create_city_wide_alerts_ajax_actions() {
-    if( ! session_id() ) { session_start(); }
-
-    add_action( 'wp_ajax_alert_closed_session', array( 'Phila_Gov_Site_Wide_Alert_Rendering', 'alert_closed_session' ) );
-    add_action( 'wp_ajax_nopriv_alert_closed_session', array( 'Phila_Gov_Site_Wide_Alert_Rendering', 'alert_closed_session' ) );
-  }
-
   /**
    * Set the session when the alert is closed. 
    */
   static function alert_closed_session() {
     if ( isset( $_POST['id_alert'] ) && is_numeric( $_POST['id_alert'] ) ) {
-      // Init session just in case if does not exists.
-      if( ! session_id() ) { session_start(); }
-
-      $_SESSION['closed-alert-' . $_POST['id_alert'] ] = true;
+      setcookie( "closed-alert-{$_POST['id_alert']}", 1, 0, '/' );
     }
     wp_die("Done!");
   }
@@ -44,7 +30,7 @@ class Phila_Gov_Site_Wide_Alert_Rendering {
       'posts_per_page'    => 1
     );
 
-    function dateTimeFormat($date){
+    function dateTimeFormat($date) {
       if ( !$date == '' ) {
         $date_obj = new DateTime("@$date");
         if( strlen($date_obj->format('F')) > 5 ){
@@ -75,45 +61,52 @@ class Phila_Gov_Site_Wide_Alert_Rendering {
 
         $now = current_time('timestamp');
 
-        if ( ( ( $alert_start <= $now && $alert_end >= $now )
-          && ! isset( $_SESSION['closed-alert-' . get_the_ID()] ) )
-          || ( is_preview() && is_singular( 'site_wide_alert' ) ) ) :
+        // Get off the "if", if the alert_end time is past today.
+        if ( ! empty( $alert_end ) && $alert_end < $now ) {
+          wp_reset_postdata();
+          return;
+        };
 
-        ?><div id="site-wide-alert" data-swiftype-index="false" data-closable>
-        <div class="row">
-          <div class="medium-centered">
-            <div class="row equal-height pvs">
-              <div class="small-1 columns center equal icon hide-for-small-only">
-                <div class="valign">
-                  <div class="valign-cell">
-                    <i class="fa fa-exclamation fa-5x" aria-hidden="true"></i>
+        if ( $alert_start <= $now || ( is_preview() && is_singular( 'site_wide_alert' ) ) ) :
+        ?>
+        <div id="site-wide-alert" data-swiftype-index="false" data-closable>
+          <div class="row">
+            <div class="medium-centered">
+              <div class="grid-x align-middle pvs">
+                <div class="small-1 cell center icon hide-for-small-only">
+                  <div class="valign">
+                    <div class="valign-cell">
+                      <i class="fa fa-exclamation fa-5x" aria-hidden="true"></i>
+                    </div>
                   </div>
                 </div>
+              <div class="small-22 cell message">
+                <?php
+                  $content = get_the_content();
+                  echo $content;
+                  ?><div class="dates pts"><?php
+                  echo 'In effect: ';
+                  dateTimeFormat($alert_start);
+                  echo ' to ';
+                  if ( empty( $alert_end ) ) {
+                    echo ' until further notice';
+                  } else {
+                    dateTimeFormat($alert_end);
+                  }
+                ?>
               </div>
-            <div class="small-22 columns equal message">
-
+                </div>
+                <div class="small-1 cell message">
+                  <button class="close-button" data-id-alert="<?php the_ID();  ?>" data-close>&times;</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
         <?php
-          $content = get_the_content();
-          echo $content;
-          ?><div class="dates pts"><?php
-          echo 'In effect: ';
-          dateTimeFormat($alert_start);
-          echo ' to ';
-          dateTimeFormat($alert_end);
-        ?>
-        </div>
-          </div>
-          <div class="small-1 columns equal message">
-            <button class="close-button" data-id-alert="<?php the_ID();  ?>" data-close>&times;</button>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-    <?php endif;
-    }//end while
-  }
-  wp_reset_postdata();
-
+        endif;
+      }//end while
+    }
+    wp_reset_postdata();
   }
 }

--- a/wp/wp-content/plugins/phila.gov-customization/public/class-phila-gov-site-wide-alert-rendering.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/class-phila-gov-site-wide-alert-rendering.php
@@ -5,6 +5,29 @@ if ( class_exists( "Phila_Gov_Site_Wide_Alert_Rendering" ) ){
 
 class Phila_Gov_Site_Wide_Alert_Rendering {
 
+  /** 
+   * Create the ajax actions to set a session when the alert is closed. 
+   */ 
+  public static function create_city_wide_alerts_ajax_actions() {
+    if( ! session_id() ) { session_start(); }
+
+    add_action( 'wp_ajax_alert_closed_session', array( 'Phila_Gov_Site_Wide_Alert_Rendering', 'alert_closed_session' ) );
+    add_action( 'wp_ajax_nopriv_alert_closed_session', array( 'Phila_Gov_Site_Wide_Alert_Rendering', 'alert_closed_session' ) );
+  }
+
+  /**
+   * Set the session when the alert is closed. 
+   */
+  static function alert_closed_session() {
+    if ( isset( $_POST['id_alert'] ) && is_numeric( $_POST['id_alert'] ) ) {
+      // Init session just in case if does not exists.
+      if( ! session_id() ) { session_start(); }
+
+      $_SESSION['closed-alert-' . $_POST['id_alert'] ] = true;
+    }
+    wp_die("Done!");
+  }
+
   /**
   * TODO: set cookie when button is closed, remember until alert is updated
   * Display alert if display is true, also show on preview
@@ -52,7 +75,9 @@ class Phila_Gov_Site_Wide_Alert_Rendering {
 
         $now = current_time('timestamp');
 
-        if ( ( $alert_start <= $now && $alert_end >= $now ) || ( is_preview() && is_singular( 'site_wide_alert' ) ) ) :
+        if ( ( ( $alert_start <= $now && $alert_end >= $now )
+          && ! isset( $_SESSION['closed-alert-' . get_the_ID()] ) )
+          || ( is_preview() && is_singular( 'site_wide_alert' ) ) ) :
 
         ?><div id="site-wide-alert" data-swiftype-index="false" data-closable>
         <div class="row">
@@ -79,7 +104,7 @@ class Phila_Gov_Site_Wide_Alert_Rendering {
         </div>
           </div>
           <div class="small-1 columns equal message">
-            <button class="close-button" data-close>&times;</button>
+            <button class="close-button" data-id-alert="<?php the_ID();  ?>" data-close>&times;</button>
           </div>
         </div>
       </div>

--- a/wp/wp-content/themes/phila.gov-theme/css/scss/_alerts.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/_alerts.scss
@@ -1,0 +1,3 @@
+#site-wide-alert {
+    display: none;
+}

--- a/wp/wp-content/themes/phila.gov-theme/css/scss/base.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/base.scss
@@ -38,6 +38,7 @@
 @import 'things-to-do';
 @import 'our-locations';
 @import 'linked-image-grid';
+@import 'alerts';
 
 @import 'beta/home';
 

--- a/wp/wp-content/themes/phila.gov-theme/functions.php
+++ b/wp/wp-content/themes/phila.gov-theme/functions.php
@@ -281,23 +281,20 @@ function phila_gov_scripts() {
 
   wp_enqueue_style( 'standards', get_stylesheet_directory_uri() . '/css/styles' . $GLOBALS['phila_is_minified'] . '.css' );
 
+  // Set the admin ajax URL global.
+  $js_vars = array(
+    'ajaxurl' => admin_url( 'admin-ajax.php' )
+  );
+
   if ( ( !is_404() ) && (!is_front_page()) ) {
     $post_obj = get_post_type_object( $post->post_type );
-
-    // Set the admin ajax URL global.
-    $js_vars = array(
-      'ajaxurl' => admin_url( 'admin-ajax.php' )
-    );
-    if ( ( !is_404() ) && (!is_front_page()) ) {
-      $post_obj = get_post_type_object( $post->post_type );
-      $js_vars = array_merge( $js_vars, array(
-        'postID' => $post->ID,
-        'postType' => $post->post_type,
-        'postRestBase' => $post_obj->rest_base,
-      ));
-    }
-    wp_localize_script( 'phila-scripts', 'phila_js_vars', $js_vars );
+    $js_vars = array_merge( $js_vars, array(
+      'postID' => $post->ID,
+      'postType' => $post->post_type,
+      'postRestBase' => $post_obj->rest_base,
+    ));
   }
+  wp_localize_script( 'phila-scripts', 'phila_js_vars', $js_vars );
 
   if( is_page_template( 'templates/the-latest-archive.php' ) ||     is_post_type_archive( 'document' ) || is_page_template( 'templates/the-latest-events-archive.php' ) ||
   is_post_type_archive( 'programs' ) ){
@@ -1578,9 +1575,4 @@ function phila_get_post_label( $label ){
     }
     return $label;
   }
-}
-
-// Initialize the Site wide alert ajax session actions
-if ( function_exists('Phila_Gov_Site_Wide_Alert_Rendering') ) {
-  Phila_Gov_Site_Wide_Alert_Rendering::create_city_wide_alerts_ajax_actions();
 }

--- a/wp/wp-content/themes/phila.gov-theme/functions.php
+++ b/wp/wp-content/themes/phila.gov-theme/functions.php
@@ -283,12 +283,20 @@ function phila_gov_scripts() {
 
   if ( ( !is_404() ) && (!is_front_page()) ) {
     $post_obj = get_post_type_object( $post->post_type );
-    wp_localize_script('phila-scripts', 'phila_js_vars', array(
-      'postID' => $post->ID,
-      'postType' => $post->post_type,
-      'postRestBase' => $post_obj->rest_base,
-      )
+
+    // Set the admin ajax URL global.
+    $js_vars = array(
+      'ajaxurl' => admin_url( 'admin-ajax.php' )
     );
+    if ( ( !is_404() ) && (!is_front_page()) ) {
+      $post_obj = get_post_type_object( $post->post_type );
+      $js_vars = array_merge( $js_vars, array(
+        'postID' => $post->ID,
+        'postType' => $post->post_type,
+        'postRestBase' => $post_obj->rest_base,
+      ));
+    }
+    wp_localize_script( 'phila-scripts', 'phila_js_vars', $js_vars );
   }
 
   if( is_page_template( 'templates/the-latest-archive.php' ) ||     is_post_type_archive( 'document' ) || is_page_template( 'templates/the-latest-events-archive.php' ) ||
@@ -1570,4 +1578,9 @@ function phila_get_post_label( $label ){
     }
     return $label;
   }
+}
+
+// Initialize the Site wide alert ajax session actions
+if ( function_exists('Phila_Gov_Site_Wide_Alert_Rendering') ) {
+  Phila_Gov_Site_Wide_Alert_Rendering::create_city_wide_alerts_ajax_actions();
 }

--- a/wp/wp-content/themes/phila.gov-theme/js/dev/main.js
+++ b/wp/wp-content/themes/phila.gov-theme/js/dev/main.js
@@ -2,6 +2,7 @@ var $ = require('jquery');
 
 require('phila-standards');
 
+require('./site-wide-alerts');
 require('./city-directory-list');
 require('./collapsible-div');
 require('./document-tables');

--- a/wp/wp-content/themes/phila.gov-theme/js/dev/site-wide-alerts.js
+++ b/wp/wp-content/themes/phila.gov-theme/js/dev/site-wide-alerts.js
@@ -1,6 +1,13 @@
-$(function() { 
-    $('#site-wide-alert .close-button').on('click', function() { 
-        var id_alert = $(this).data('id-alert'); 
-        $.post( phila_js_vars.ajaxurl, { action: 'alert_closed_session', id_alert: id_alert } ); 
-    }); 
+jQuery( window ).on('load', function() {
+    if ( window.sessionStorage ) {
+        if ( ! sessionStorage.getItem('hideAlerts') ) {
+            jQuery('#site-wide-alert').slideDown();
+        }
+    }
+});
+
+jQuery('#site-wide-alert .close-button').on('click', function() {
+    if ( window.sessionStorage ) {
+        sessionStorage.setItem( 'hideAlerts', true );
+    }
 });

--- a/wp/wp-content/themes/phila.gov-theme/js/dev/site-wide-alerts.js
+++ b/wp/wp-content/themes/phila.gov-theme/js/dev/site-wide-alerts.js
@@ -1,0 +1,6 @@
+$(function() { 
+    $('#site-wide-alert .close-button').on('click', function() { 
+        var id_alert = $(this).data('id-alert'); 
+        $.post( phila_js_vars.ajaxurl, { action: 'alert_closed_session', id_alert: id_alert } ); 
+    }); 
+});


### PR DESCRIPTION
Now alerts are hidden by default and are displayed only one time by browser session with SessionStorage.
Also, if an alert is published but does not have end date and time, a message with "until further notice" replaces the end time.