### PR TITLE
Now the sitewide alert session is tied to the start date, end date an…

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/public/class-phila-gov-site-wide-alert-rendering.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/class-phila-gov-site-wide-alert-rendering.php
@@ -59,18 +59,18 @@ class Phila_Gov_Site_Wide_Alert_Rendering {
 
         if ( $alert_start <= $now || ( is_preview() && is_singular( 'site_wide_alert' ) ) ) :
         ?>
-        <div id="site-wide-alert" data-swiftype-index="false" data-closable>
+        <div id="site-wide-alert" data-alert="alert-<?php echo $alert_start ?>-<?php echo $alert_end; ?>-<?php echo get_the_ID(); ?>" data-swiftype-index="false" data-closable>
           <div class="row">
             <div class="medium-centered">
-              <div class="grid-x align-middle pvs">
-                <div class="small-1 cell center icon hide-for-small-only">
+              <div class="grid-x grid-padding-x align-top pvs">
+                <div class="cell auto shrink center icon hide-for-small-only">
                   <div class="valign">
                     <div class="valign-cell">
                       <i class="fa fa-exclamation fa-5x" aria-hidden="true"></i>
                     </div>
                   </div>
                 </div>
-              <div class="small-22 cell message">
+              <div class="cell auto message">
                 <?php
                   $content = get_the_content();
                   echo $content;
@@ -86,7 +86,7 @@ class Phila_Gov_Site_Wide_Alert_Rendering {
                 ?>
               </div>
                 </div>
-                <div class="small-1 cell message">
+                <div class="cell auto shrink message">
                   <button class="close-button" data-id-alert="<?php the_ID();  ?>" data-close>&times;</button>
                 </div>
               </div>

--- a/wp/wp-content/themes/phila.gov-theme/css/scss/_alerts.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/_alerts.scss
@@ -1,3 +1,7 @@
 #site-wide-alert {
     display: none;
+    button {
+        padding: 0;
+        margin: 0;
+    }
 }

--- a/wp/wp-content/themes/phila.gov-theme/js/dev/site-wide-alerts.js
+++ b/wp/wp-content/themes/phila.gov-theme/js/dev/site-wide-alerts.js
@@ -1,13 +1,19 @@
+var site_wide_alert = jQuery('#site-wide-alert');
 jQuery( window ).on('load', function() {
     if ( window.sessionStorage ) {
-        if ( ! sessionStorage.getItem('hideAlerts') ) {
-            jQuery('#site-wide-alert').slideDown();
+        var alert_name = site_wide_alert.data('alert');
+        if ( ! window.sessionStorage.getItem( alert_name ) ) {
+            site_wide_alert.slideDown();
         }
     }
 });
 
-jQuery('#site-wide-alert .close-button').on('click', function() {
+jQuery('.close-button', site_wide_alert).on('click', function(event) {
+    event.preventDefault();
+    site_wide_alert.slideUp();
     if ( window.sessionStorage ) {
-        sessionStorage.setItem( 'hideAlerts', true );
+        var alert_name = site_wide_alert.data('alert');
+        window.sessionStorage.setItem( alert_name, true );
     }
+    return false;
 });


### PR DESCRIPTION
…d alert id, so, when any of these are updated, the user will see the alert again even if they haven't closed their broswer session

- Also, added an extra CSS and classes for a better mobile integration with the XY Layout.