### PR TITLE
Fix robots.txt disallow rule

### DIFF
--- a/nginx/server.d/robots.conf
+++ b/nginx/server.d/robots.conf
@@ -1,3 +1,3 @@
 location /robots.txt {
-  return 200 "User-agent: *\nDisallow: \/";
+  return 200 "User-agent: *\nDisallow: /\n";
 }


### PR DESCRIPTION
I'm not 100% sure about this but I googled it and everything I found suggests this would be the right syntax, e.g.:
- http://blog.tcs.de/serve-robots-txt-inline-in-nginx/
- https://alanthing.com/blog/2017/05/15/robots-dot-txt-disallow-all-with-nginx/