### PR TITLE
Hard-code hostname in og:url meta tag

### DIFF
--- a/wp/wp-content/themes/phila.gov-theme/functions.php
+++ b/wp/wp-content/themes/phila.gov-theme/functions.php
@@ -254,7 +254,7 @@ function phila_open_graph() {
     $type = 'article';
   }
 
-  $link = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+  $link = 'https://www.phila.gov' . $_SERVER['REQUEST_URI'];
 
   //TODO: Determine which twitter account should be used for site attribution ?>
   <meta name="twitter:card" content="summary">


### PR DESCRIPTION
This fixes an issue identified by the communications office where the ELB hostname was being used
in social media shares.

I'm 🤞 that `REQUEST_URI` includes the leading `/` since I haven't tested this, but [the docs](http://php.net/manual/en/reserved.variables.server.php) suggest it does.