### PR TITLE
Bugfix/layout

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-staff-directory.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/class-phila-gov-staff-directory.php
@@ -110,7 +110,6 @@ class Phila_Gov_Staff_Directory {
           'id'  => 'units',
           'name'  => 'Associated unit',
           'type' => 'unit',
-          //'callback' => $this->phila_get_term_meta( $meta_boxes ),
         ),
         array(
           'id' => $prefix . 'staff_social',

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/meta-boxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/meta-boxes.php
@@ -476,7 +476,6 @@ function phila_register_meta_boxes( $meta_boxes ){
     'context'  => 'normal',
     'priority' => 'default',
 
-
     'include' => array(
       'user_role'  => array(
         'administrator', 'primary_department_homepage_editor', 'editor' ),
@@ -485,7 +484,6 @@ function phila_register_meta_boxes( $meta_boxes ){
       'when' => array(
         array( 'phila_template_select', '=', 'homepage_v2'),
       ),
-      'relation' => 'or',
     ),
 
     'fields' => array(
@@ -509,6 +507,18 @@ function phila_register_meta_boxes( $meta_boxes ){
         'fields' => array(
           Phila_Gov_Standard_Metaboxes::phila_metabox_category_picker('Select new owner', 'phila_staff_category', 'Display staff members from these owners. This will override page ownership selection entirely.' ),
         ),
+      ),
+      array(
+        'id'  => 'hide_units',
+        'class' => 'hide-on-load',
+        'name'  => 'Hide staff assigned to units?',
+        'desc'  => 'By selecting this option, staff assigned to a unit will not appear on this department homepage.',
+        'type' => 'switch',
+        'on_label'  => 'Yes',
+        'off_label' => 'No',
+        'visible' => array(
+          'phila_template_select', 'in', ['homepage_v2']
+        )
       ),
     ),
   );

--- a/wp/wp-content/themes/phila.gov-theme/css/lt-ie-9.css
+++ b/wp/wp-content/themes/phila.gov-theme/css/lt-ie-9.css
@@ -41,7 +41,7 @@ nav li{
   display:none !important;
 }
 
-.fa{
+.fa, .fab, .fal, .far, .fas{
   padding:10px;
 }
 

--- a/wp/wp-content/themes/phila.gov-theme/css/scss/_button.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/_button.scss
@@ -7,7 +7,7 @@
 }
 .button{
   &[class*='content-type']{
-    .fa {
+    .fa, .fab, .fal, .far, .fas{
       padding-left:.5rem;
     }
   }

--- a/wp/wp-content/themes/phila.gov-theme/css/scss/_layout.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/_layout.scss
@@ -106,7 +106,7 @@ table.connect{
     a div {
       display: block;
       text-align: center;
-      .fa {
+      .fa, .fab, .fal, .far, .fas {
         margin:0;
         font-size: 4rem;
       }

--- a/wp/wp-content/themes/phila.gov-theme/css/scss/_service-updates.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/_service-updates.scss
@@ -33,7 +33,7 @@
     color:#fff;
     font-size: 3rem;
 
-    .fa{
+    .fa, .fab, .fal, .far, .fas{
       display: inline-block;
       vertical-align: middle;
     }

--- a/wp/wp-content/themes/phila.gov-theme/css/scss/_sticky-nav.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/_sticky-nav.scss
@@ -23,7 +23,7 @@
       li{
         border-right:none;
 
-        .fa{
+        .fa, .fab, .fal, .far, .fas{
           visibility: hidden;
         }
 

--- a/wp/wp-content/themes/phila.gov-theme/css/scss/_sticky-nav.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/_sticky-nav.scss
@@ -76,7 +76,7 @@
       }
     }
     li div {
-      padding:.5rem 0 .3rem 0;
+      padding: 1rem 0 .3rem 0;
 
     }
     @include breakpoint(small only) {

--- a/wp/wp-content/themes/phila.gov-theme/css/scss/pages/_departments.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/pages/_departments.scss
@@ -10,7 +10,7 @@
   table.no-alternate tr{
     background: white;
   }
-  .fa{
+  .fa, .fab, .fal, .far, .fas{
     font-size:1.5rem;
   }
   .list-heading{

--- a/wp/wp-content/themes/phila.gov-theme/css/scss/pages/_home.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/pages/_home.scss
@@ -176,7 +176,7 @@
   }
   .process {
     .marker {
-      .fa {
+      .fa, .fab, .fal, .far, .fas {
           width: 100%;
       }
     }

--- a/wp/wp-content/themes/phila.gov-theme/css/scss/pages/_post.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/pages/_post.scss
@@ -19,7 +19,7 @@
         padding: $spacing-small;
       }
 
-      .fa {
+      .fa, .fab, .fal, .far, .fas {
         font-size: 1.5rem;
         @include breakpoint(small only) {
           font-size: 2rem;

--- a/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Archives.vue
+++ b/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Archives.vue
@@ -96,6 +96,7 @@
     :async="true"
     :limit="3"
     :show-step-links="true"
+    :hide-single-page="false"
     :step-links="{
       next: 'Next',
       prev: 'Previous'

--- a/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Archives.vue
+++ b/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Archives.vue
@@ -62,47 +62,54 @@
     <div v-show="loading" class="mtm center">
       <i class="fas fa-spinner fa-spin fa-3x"></i>
     </div>
-    <div v-show="emptyResponse" class="h3 mtm center">Sorry, there are no results.</div>
+    <div v-show="!loading && emptyResponse" class="h3 mtm center">Sorry, there are no results.</div>
     <div v-show="failure" class="h3 mtm center">Sorry, there was a problem. Please try again.</div>
 
-    <table class="stack theme-light archive-results"  data-sticky-container v-show="!loading && !emptyResponse && !failure">
-      <thead class="sticky center bg-white" data-sticky data-top-anchor="filter-results:bottom" data-btm-anchor="page:bottom" data-options="marginTop:4.8;">
-        <tr><th class="title">Title</th><th class="date">Publish date</th><th>Department</th></tr>
-      </thead>
-      <paginate name="posts"
-        :list="posts"
-        class="paginate-list"
-        tag="tbody"
-        :per="40">
-        <tr v-for="post in paginated('posts')"
-        :key="post.id"
-        class="vue-clickable-row"
-        v-on:click.stop.prevent="goToPost(post.link)">
-          <td class="title">
-            <a v-bind:href="post.link" v-on:click.prevent="goToPost(post.link)">
-              {{ post.title }}
-            </a>
-          </td>
-          <td class="date">{{ post.date  | formatDate }}</td>
-          <td class="categories">
-            <span v-for="(category, i) in post.categories">
-              <span>{{ category.slang_name }}</span><span v-if="i < post.categories.length - 1">,&nbsp;</span>
-            </span>
-          </td>
-        </tr>
-      </paginate>
-    </table>
-    <paginate-links for="posts"
-    :async="true"
-    :limit="3"
-    :show-step-links="true"
-    :hide-single-page="false"
-    :step-links="{
-      next: 'Next',
-      prev: 'Previous'
-    }"
-    v-show="!loading && !emptyResponse && !failure"></paginate-links>
+    <div v-if="posts.length">
+      <table class="stack theme-light archive-results"  data-sticky-container v-show="!loading && !emptyResponse && !failure">
+        <thead class="sticky center bg-white" data-sticky data-top-anchor="filter-results:bottom" data-btm-anchor="page:bottom" data-options="marginTop:4.8;">
+          <tr><th class="title">Title</th><th class="date">Publish date</th><th>Department</th></tr>
+        </thead>
+        <paginate name="posts"
+          :list="posts"
+          class="paginate-list"
+          tag="tbody"
+          :per="40">
+          <tr v-for="post in paginated('posts')"
+          :key="post.id"
+          class="vue-clickable-row"
+          v-on:click.stop.prevent="goToPost(post.link)">
+            <td class="title">
+              <a v-bind:href="post.link" v-on:click.prevent="goToPost(post.link)">
+                {{ post.title }}
+              </a>
+            </td>
+            <td class="date">{{ post.date  | formatDate }}</td>
+            <td class="categories">
+              <span v-for="(category, i) in post.categories">
+                <span>{{ category.slang_name }}</span><span v-if="i < post.categories.length - 1">,&nbsp;</span>
+              </span>
+            </td>
+          </tr>
+        </paginate>
+      </table>
+      <paginate-links for="posts"
+      :async="true"
+      :limit="3"
+      :show-step-links="true"
+      :hide-single-page="false"
+      :step-links="{
+        next: 'Next',
+        prev: 'Previous'
+      }"
+      v-show="!loading && !emptyResponse && !failure"></paginate-links>
+    </div>
+    <div v-else>
+      <div v-show="!emptyResponse" class="h3 mtm center">Sorry, there are no results.
+      </div>
+    </div>
   </div>
+
   </template>
 
 <script>
@@ -232,28 +239,14 @@ export default {
       })
     },
     reset() {
-      //this.loading = true
-      window.location = window.location.pathname;
-      /*this.selectedCategory = ''
-      axios.get(endpoint + 'archives', {
-       params : {
-          'count': -1
-        }
-      })
-        .then(response => {
-          this.posts = response.data
-          this.loading = false
-          this.searchedVal = ''
-          this.checkedTemplates = ''
-          this.selectedCategory = ''
-          this.state.startDate = ''
-          this.state.endDate = ''
-        })
-        .catch(e => {
-          this.failure = true
-      })
-      this.$forceUpdate();
-      */
+
+      this.searchedVal = ''
+      this.state.startDate = ''
+      this.state.endDate = ''
+      //a little convoluted, but will change the state of selected if the reset button is used mutiple times in a session
+      this.selected = (this.selected == null ? '' : null)
+      this.runDateQuery()
+      this.filterByCategory()
     },
     runDateQuery(){
       if ( !this.state.startDate || !this.state.endDate )
@@ -282,36 +275,35 @@ export default {
       })
     },
     filterByCategory: function(selectedVal){
-      this.$nextTick(function () {
-        this.loading = true
+      this.loading = true
 
-        this.selectedCategory = (selectedVal) ? selectedVal.id : ''
+      this.selectedCategory = (selectedVal) ? selectedVal.id : ''
 
-        axios.get(endpoint + 'archives', {
-          params : {
-            's': this.searchedVal,
-            'tag': this.tagVal,
-            'template': this.checkedTemplates,
-            'category': this.selectedCategory,
-            'count': -1,
-            'start_date': this.state.startDate,
-            'end_date': this.state.endDate,
-            }
-          })
-          .then(response => {
-            this.loading = false
-            //Don't let empty value change the rendered view
-          //  if ('id' in selectedVal && this.queriedCategory != ''){
-              this.posts = response.data
-          //  }
-
-            this.successfulResponse
-          })
-          .catch(e => {
-            this.failure = true
-            this.loading = false
+      axios.get(endpoint + 'archives', {
+        params : {
+          's': this.searchedVal,
+          'tag': this.tagVal,
+          'template': this.checkedTemplates,
+          'category': this.selectedCategory,
+          'count': -1,
+          'start_date': this.state.startDate,
+          'end_date': this.state.endDate,
+          }
         })
+        .then(response => {
+          this.loading = false
+          //Don't let empty value change the rendered view
+        //  if ('id' in selectedVal && this.queriedCategory != ''){
+            this.posts = response.data
+        //  }
+
+          this.successfulResponse
+        })
+        .catch(e => {
+          this.failure = true
+          this.loading = false
       })
+
     },
   },
   computed:{

--- a/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Publications.vue
+++ b/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Publications.vue
@@ -88,8 +88,9 @@
     </table>
     <paginate-links for="documents"
     :limit="3"
+    :async="true"
     :show-step-links="true"
-    :hide-single-page="true"
+    :hide-single-page="false"
     :step-links="{
       next: 'Next',
       prev: 'Previous'

--- a/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Publications.vue
+++ b/wp/wp-content/themes/phila.gov-theme/js/vuesrc/Publications.vue
@@ -48,55 +48,62 @@
     <div v-show="loading" class="mtm center">
       <i class="fas fa-spinner fa-spin fa-3x"></i>
     </div>
-    <div v-show="emptyResponse" class="h3 mtm center">Sorry, there are no results.</div>
+    <div v-show="!loading && emptyResponse" class="h3 mtm center">Sorry, there are no results.</div>
     <div v-show="failure" class="h3 mtm center">Sorry, there was a problem. Please try again.</div>
 
-    <table class="stack theme-light archive-results"  data-sticky-container v-show="!loading && !emptyResponse && !failure">
-      <thead class="sticky center bg-white" data-sticky data-top-anchor="filter-results:bottom" data-btm-anchor="page:bottom" data-options="marginTop:4.8;">
-        <tr>
-          <th class="table-sort title"
-          @click="sort('title')" v-bind:class="sortTitle"><span>Title</span></th>
+      <div v-if="sortedDocuments.length">
+        <table class="stack theme-light archive-results"  data-sticky-container v-show="!loading && !emptyResponse && !failure">
+          <thead class="sticky center bg-white" data-sticky data-top-anchor="filter-results:bottom" data-btm-anchor="page:bottom" data-options="marginTop:4.8;">
+            <tr>
+              <th class="table-sort title"
+              @click="sort('title')" v-bind:class="sortTitle"><span>Title</span></th>
 
-          <th class="table-sort date"
-          @click="sort('date')"
-          v-bind:class="sortDate"><span>Publish date</span></th>
-          <th class="department">Department</th>
-        </tr>
-      </thead>
-      <paginate name="documents"
-        :list="sortedDocuments"
-        class="paginate-list"
-        tag="tbody"
-        :per="40">
-        <tr v-for="document in paginated('documents')"
-        :key="document.id"
-        class="vue-clickable-row"
-        v-on:click.stop.prevent="goToDoc(document.link)">
-          <td class="title">
-            <a v-bind:href="document.link" v-on:click.prevent="goToDoc(document.link)">
-              {{ document.title }}
-            </a>
-          </td>
-          <td class="date">{{ document.date  | formatDate }}</td>
-          <td class="categories">
-            <span v-for="(category, i) in document.categories">
-              <span>{{ category.slang_name }}</span><span v-if="i < document.categories.length - 1">,&nbsp;</span>
-            </span>
-          </td>
-        </tr>
-      </paginate>
-    </table>
-    <paginate-links for="documents"
-    :limit="3"
-    :async="true"
-    :show-step-links="true"
-    :hide-single-page="false"
-    :step-links="{
-      next: 'Next',
-      prev: 'Previous'
-    }"
-    v-show="!loading && !emptyResponse && !failure"></paginate-links>
-  </div>
+              <th class="table-sort date"
+              @click="sort('date')"
+              v-bind:class="sortDate"><span>Publish date</span></th>
+              <th class="department">Department</th>
+            </tr>
+          </thead>
+
+          <paginate name="documents"
+            :list="sortedDocuments"
+            class="paginate-list"
+            tag="tbody"
+            :per="40">
+            <tr v-for="document in paginated('documents')"
+            :key="document.id"
+            class="vue-clickable-row"
+            v-on:click.stop.prevent="goToDoc(document.link)">
+              <td class="title">
+                <a v-bind:href="document.link" v-on:click.prevent="goToDoc(document.link)">
+                  {{ document.title }}
+                </a>
+              </td>
+              <td class="date">{{ document.date  | formatDate }}</td>
+              <td class="categories">
+                <span v-for="(category, i) in document.categories">
+                  <span>{{ category.slang_name }}</span><span v-if="i < document.categories.length - 1">,&nbsp;</span>
+                </span>
+              </td>
+            </tr>
+          </paginate>
+        </table>
+        <paginate-links for="documents"
+        :limit="3"
+        :async="true"
+        :show-step-links="true"
+        :hide-single-page="false"
+        @change="onDocsPageChange"
+        :step-links="{
+          next: 'Next',
+          prev: 'Previous'
+        }"
+        v-show="!loading && !emptyResponse && !failure"></paginate-links>
+      </div>
+      <div v-else>
+        <div v-show="!emptyResponse" class="h3 mtm center">Sorry, there are no results.</div>
+      </div>
+    </div>
   </template>
 
 <script>
@@ -177,6 +184,10 @@ export default {
     })
   },
   methods: {
+    onDocsPageChange (toPage, fromPage) {
+      console.log(toPage)
+      console.log(fromPage)
+      },
     getDropdownCategories: function () {
       axios.get('/wp-json/the-latest/v1/categories')
       .then(response => {
@@ -290,7 +301,7 @@ export default {
         this.failure = false
       }
     },
-    sortedDocuments:function() {
+    sortedDocuments: function() {
       return this.filteredList(this.documents.sort((a,b) => {
         let modifier = 1;
         if(this.currentSortDir === 'desc') modifier = -1;

--- a/wp/wp-content/themes/phila.gov-theme/package-lock.json
+++ b/wp/wp-content/themes/phila.gov-theme/package-lock.json
@@ -1273,7 +1273,6 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
-      "optional": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -1603,7 +1602,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -1875,9 +1874,9 @@
       }
     },
     "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -2412,7 +2411,6 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
-      "optional": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -2857,13 +2855,13 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "1.0.6",
+        "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
     },
@@ -3612,12 +3610,12 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
       "dev": true,
       "requires": {
-        "ajv": "^5.1.0",
+        "ajv": "^5.3.0",
         "har-schema": "^2.0.0"
       }
     },
@@ -3927,7 +3925,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -4160,8 +4158,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "jsesc": {
       "version": "0.5.0",
@@ -4288,7 +4285,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -4488,7 +4485,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -4542,18 +4539,18 @@
       }
     },
     "mime-db": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
-      "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.35.0"
+        "mime-db": "~1.37.0"
       }
     },
     "mimic-fn": {
@@ -4720,9 +4717,9 @@
       }
     },
     "node-sass": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.3.tgz",
-      "integrity": "sha512-XzXyGjO+84wxyH7fV6IwBOTrEBe2f0a6SBze9QWWYR/cL74AcQUks2AsqcCZenl/Fp/JVbuEaLpgrLtocwBUww==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.4.tgz",
+      "integrity": "sha512-MXyurANsUoE4/6KmfMkwGcBzAnJQ5xJBGW7Ei6ea8KnUKuzHr/SguVBIi3uaUAHtZCPUYkvlJ3Ef5T5VAwVpaA==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -4740,7 +4737,7 @@
         "nan": "^2.10.0",
         "node-gyp": "^3.8.0",
         "npmlog": "^4.0.0",
-        "request": "2.87.0",
+        "request": "^2.88.0",
         "sass-graph": "^2.2.4",
         "stdout-stream": "^1.4.0",
         "true-case-path": "^1.0.2"
@@ -4828,9 +4825,9 @@
       "dev": true
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
     "object-assign": {
@@ -4917,7 +4914,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -7128,6 +7125,12 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
+    "psl": {
+      "version": "1.1.29",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+      "dev": true
+    },
     "public-encrypt": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
@@ -7421,31 +7424,39 @@
       }
     },
     "request": {
-      "version": "2.87.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
+        "aws4": "^1.8.0",
         "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
         "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "tough-cookie": "~2.3.3",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "require-directory": {
@@ -7817,9 +7828,9 @@
       "dev": true
     },
     "spdx-correct": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
+      "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -7827,9 +7838,9 @@
       }
     },
     "spdx-exceptions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
       "dev": true
     },
     "spdx-expression-parse": {
@@ -7843,9 +7854,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
+      "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
       "dev": true
     },
     "split-string": {
@@ -7864,9 +7875,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.1.tgz",
+      "integrity": "sha512-mSdgNUaidk+dRU5MhYtN9zebdzF2iG0cNPWy8HG+W8y+fT1JnSkh0fzzpjOa0L7P8i1Rscz38t0h4gPcKz43xA==",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -7902,9 +7913,9 @@
       }
     },
     "stdout-stream": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
-      "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
+      "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.1"
@@ -8153,11 +8164,12 @@
       }
     },
     "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
+        "psl": "^1.1.24",
         "punycode": "^1.4.1"
       }
     },
@@ -8209,27 +8221,12 @@
       "dev": true
     },
     "true-case-path": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
-      "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
+      "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
       "dev": true,
       "requires": {
-        "glob": "^6.0.4"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "dev": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
+        "glob": "^7.1.2"
       }
     },
     "tty-browserify": {
@@ -8251,8 +8248,7 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",

--- a/wp/wp-content/themes/phila.gov-theme/package-lock.json
+++ b/wp/wp-content/themes/phila.gov-theme/package-lock.json
@@ -1602,7 +1602,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -3925,7 +3925,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -4285,7 +4285,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -4485,7 +4485,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -4914,7 +4914,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {

--- a/wp/wp-content/themes/phila.gov-theme/package.json
+++ b/wp/wp-content/themes/phila.gov-theme/package.json
@@ -39,7 +39,7 @@
     "browserify-shim": "^3.8.14",
     "envify": "^4.1.0",
     "hoek": "^5.0.4",
-    "node-sass": "^4.9.3",
+    "node-sass": "^4.9.4",
     "postcss-cli": "^5.0.1",
     "vueify": "^9.4.0"
   },

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/phila_staff_directory_listing.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/phila_staff_directory_listing.php
@@ -21,10 +21,10 @@ if ( has_category() ) {
     $category_id = implode(", ", $category_override['phila_staff_category']);
   }
 
-  if (!empty($unit_data) ) {
-    foreach ($unit_data as $unit){
-      /* The Staff Directory Loop, when there are units */
+  if (!empty( $unit_data ) ) {
 
+    foreach ( $unit_data as $unit ){
+      /* The Staff Directory Loop, when there are units */
       $args = array(
         'orderby' => 'title',
         'order' => 'ASC',
@@ -60,18 +60,43 @@ if ( has_category() ) {
       include(locate_template('partials/departments/phila_staff_directory_loop.php'));
 
     }else{
+      $hidden = rwmb_meta('hide_units');
 
-      /* There are no units, display normally */
-      $args = array(
-        'orderby' => 'title',
-        'order' => 'ASC',
-        'post_type' => 'staff_directory',
-        'cat' => array($category_id),
-        'posts_per_page' => -1,
+      if ( !empty( $hidden ) ) {
+        $args = array(
+          'orderby' => 'title',
+          'order' => 'ASC',
+          'post_type' => 'staff_directory',
+          'cat' => array($category_id),
+          'posts_per_page' => -1,
+          'meta_query' => array(
+            'relation' => 'AND',
+            array(
+              'key'     => 'units',
+              'value'   => '',
+              'compare' => 'NOT EXISTS'
+            )
+          )
         );
 
-      include(locate_template('partials/departments/phila_staff_directory_loop.php'));
+        $unit = null;
+        include(locate_template('partials/departments/phila_staff_directory_loop.php'));
+
+      } else {
+
+        /* There are no units, display normally */
+        $args = array(
+          'orderby' => 'title',
+          'order' => 'ASC',
+          'post_type' => 'staff_directory',
+          'cat' => array($category_id),
+          'posts_per_page' => -1,
+          );
+
+        include(locate_template('partials/departments/phila_staff_directory_loop.php'));
+      }
     }
+
   }?>
 
 <?php if (phila_get_selected_template() != 'homepage_v2') : ?>

--- a/wp/wp-content/themes/phila.gov-theme/partials/posts/press-release-grid.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/posts/press-release-grid.php
@@ -16,17 +16,6 @@
 
 <?php
 
-//if categories aren't set then, this is the latest, don't show featured
-if ( empty( $press_categories ) ) {
-  $press_meta_query  = array(
-    'key' => 'phila_is_feature',
-    'value' => '0',
-    'compare' => '=',
-  );
-}else{
-  $press_meta_query = array();
-}
-
 if( !empty($tag) ) {
   $press_release_template_args  = array(
     'posts_per_page' => 4,
@@ -59,7 +48,6 @@ if( !empty($tag) ) {
           'value' => 'press_release',
           'compare' => '=',
         ),
-      $press_meta_query
     ),
   );
 }


### PR DESCRIPTION
* Adjust FontAwesome 5 css in certain templates. 
* Fix press release rendering on the latest landing page to show newest press releases
* Adjust pagination for archives and document landing pages so rendering doesn't break when results array is empty. 
* Adds option to hide staff within units on a department homepage (requested for Planning + Development)