### PR TITLE
Bugfix/staff

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-custom-unit.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-custom-unit.php
@@ -17,7 +17,7 @@ if ( class_exists( 'RWMB_Field' ) ) {
 
       /**
        * gets the post status.
-       * TODO: Move into seperate class
+       * TODO: Move into separate class
       */
       public static function is_edit_page( $new_edit = null ){
         global $pagenow;

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/phila_staff_directory_listing.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/phila_staff_directory_listing.php
@@ -7,11 +7,11 @@
 ?>
 <?php
 global $post;
+
 $user_selected_template = phila_get_selected_template();
-
 $category_override = rwmb_meta('phila_get_staff_cats');
+$unit_data = get_post_meta( $post->ID, 'units' );
 
-$unit_data = rwmb_meta('units');
 
 if ( has_category() ) {
   $categories = get_the_category();


### PR DESCRIPTION
After the metabox update, unit data was not being displayed properly on the front-end. Switching to `get_post_meta()` from `rwmb_meta` solves the problem.