### PR TITLE
Bugfix/see all

### DIFF
--- a/wp/wp-content/themes/phila.gov-theme/partials/event-spotlight/featured-events.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/event-spotlight/featured-events.php
@@ -65,12 +65,12 @@
                 <?php elseif ($start ->format('m-d') === $end->format('m-d') && $start->format('a') !== $end->format('a')): ?>
                   <?php $date_output = str_replace(
                       array('Sep','12:00 am','12:00 pm','am','pm',':00'),
-                      array('Sept','midnight','noon','a.m.','p.m.', ''), $start->format('<b>'.' l, ' . $start_month_format .  ' j, Y'. '</b>') .'<br /><i>' . $start->format( 'g:i a' ) . ' to ' . $end->format(' g:i a') . '</i>' );
+                      array('Sept','midnight','noon','a.m.','p.m.', ''), $start->format('<b>'.' l, ' . $start_month_format .  ' j, Y'. '</b>') .'<br /><i>' . $start->format( 'g:i a' ) . ' - ' . $end->format(' g:i a') . '</i>' );
                       echo $date_output;?>
                 <?php else : //date range ?>
                   <?php $date_output = str_replace(
                     array('Sep','12:00 am','12:00 pm','am','pm',':00'),
-                    array('Sept','midnight','noon','a.m.','p.m.',''), $start->format('<b>' . $start_month_format . ' j') . ' to ' . $end->format( $end_month_format . ' j, Y' . '</b>') );
+                    array('Sept','midnight','noon','a.m.','p.m.',''), $start->format('<b>' . $start_month_format . ' j') . ' - ' . $end->format( $end_month_format . ' j, Y' . '</b>') );
                     echo $date_output;
                     ?>
                 <?php endif; ?>

--- a/wp/wp-content/themes/phila.gov-theme/partials/event-spotlight/featured-events.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/event-spotlight/featured-events.php
@@ -65,7 +65,7 @@
                 <?php elseif ($start ->format('m-d') === $end->format('m-d') && $start->format('a') !== $end->format('a')): ?>
                   <?php $date_output = str_replace(
                       array('Sep','12:00 am','12:00 pm','am','pm',':00'),
-                      array('Sept','midnight','noon','a.m.','p.m.', ''), $start->format('<b>'.' l, ' . $start_month_format .  ' j, Y'. '</b>') .'<br /><i>' . $start->format( 'g:i a' ) . ' - ' . $end->format(' g:i a') . '</i>' );
+                      array('Sept','midnight','noon','a.m.','p.m.', ''), $start->format('<b>'.' l, ' . $start_month_format .  ' j, Y'. '</b>') .'<br /><i>' . $start->format( 'g:i a' ) . ' to ' . $end->format(' g:i a') . '</i>' );
                       echo $date_output;?>
                 <?php else : //date range ?>
                   <?php $date_output = str_replace(

--- a/wp/wp-content/themes/phila.gov-theme/partials/posts/content-card.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/posts/content-card.php
@@ -10,7 +10,7 @@
 
 <?php $label_arr = phila_get_post_label($label);
   $article_classes = 'flex-child-auto '; ?>
-<?php if ($count == 3 && $label_arr['label'] == 'featured') : ?>
+<?php if ($count === 3 && $label_arr['label'] === 'featured') : ?>
   <?php $is_last = true; ?>
 <?php endif; ?>
 
@@ -27,7 +27,7 @@
 <?php $last = isset($is_last) ? true : false; ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class( $article_classes ); ?>>
-  <a <?php echo ($label_arr['label'] !== 'announcement') ? 'href=' . get_permalink() : '' ?> class="card card--<?php echo $label_arr['label'] ?> <?php echo ($last && $label_arr['label'] !== 'announcement') ? 'card--last' : ''; ?> pam" <?php echo ($label_arr['label'] == 'announcement') ? 'data-open="announcement-' . get_the_ID() .'"' : ''?>>
+  <a <?php echo ($label_arr['label'] !== 'announcement') ? 'href=' . get_permalink() : '' ?> class="card card--<?php echo $label_arr['label'] ?> <?php echo ($is_last && $label_arr['label'] !== 'announcement') ? 'card--last' : ''; ?> pam" <?php echo ($label_arr['label'] == 'announcement') ? 'data-open="announcement-' . get_the_ID() .'"' : ''?>>
     <div class="grid-x flex-dir-column card--content">
       <div class="cell align-self-top post-label post-label--<?php echo $label_arr['label']?>">
         <i class="<?php echo $label_arr['icon'] ?> fa-lg" aria-hidden="true"></i> <span><?php echo $label_arr['nice']; ?></span>

--- a/wp/wp-content/themes/phila.gov-theme/partials/posts/post-grid.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/posts/post-grid.php
@@ -151,10 +151,22 @@ $result->post_count = count( $result->posts );
               $see_all = array_replace( $see_all, $see_all_URL );
               endif;?>
               <?php if( !empty( $tag ) ) :
-                $term = get_term($tag[0], 'post_tag');
-                $see_all_URL = array(
-                  'URL' => '/the-latest/archives/?tag=' . $term->name,
-                ); ?>
+                  if( gettype($tag) === 'array'):
+                    $term = [];
+                    foreach($tag as $t) {
+                      $name = get_term($t, 'post_tag');
+                      array_push($term, $name->name);
+                    }
+                    $term = implode(', ', $term);
+                    $see_all_URL = array(
+                      'URL' => '/the-latest/archives/?tag=' . $term,
+                    );
+                  else: 
+                    $term = get_term($tag, 'post_tag');
+                    $see_all_URL = array(
+                      'URL' => '/the-latest/archives/?tag=' . $term->name,
+                    );
+                  endif; ?>
               <?php if (!empty($override_url)) : ?>
               <?php $see_all_URL = array(
                   'URL' => $override_url


### PR DESCRIPTION
Corrects "see all" links not improperly passing a string instead of an array in certain templates. Improves tag handling to allow multiple tags on a "see all" link. 