### PR TITLE
Reset post_max_size

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -30,7 +30,7 @@ g/^pm\.max_children/s/10/20
 w
 EOF
 sudo ed -s /etc/php/7.2/fpm/php.ini <<'EOF'
-g/^post_max_size/s/100/1000
+g/^post_max_size/s/8/1000
 g/^upload_max_filesize/s/2/100
 g/^memory_limit/s/128/1024
 g/^; max_input_vars = 1000/s//max_input_vars = 100000


### PR DESCRIPTION
When new production machines get created, they'll start with the 8M defualt, so revert the replacement to 8, and set to a new max of 1000