### PR TITLE
Phone connect field + admin bugfix

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/js/admin-department-author.js
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/js/admin-department-author.js
@@ -121,19 +121,28 @@ jQuery(document).ready(function($){
   }
 
   if ( ( typenow == 'post') && adminpage.indexOf('post') > -1 ){
+
+    //remove other options from the post dropdown unless that user has specific permissions to do it
     $('#phila_template_select option').each( function () {
       if( $(this).val() !== '' && $(this).val() !== 'post' ){
         $(this).css('display', 'none');
-      }
+      } 
     });
+      //ensure users who only have access to posts get the option preselcted for them
+    if (!phila_WP_User.includes('secondary_press_release_editor') && 
+      !phila_WP_User.includes('secondary_press_release_contributor') &&
+      !phila_WP_User.includes( 'secondary_action_guide_editor' )){
+      $("#phila_template_select").val('post');
+    }
+
     if( phila_WP_User.includes('secondary_press_release_editor') || phila_WP_User.includes('secondary_press_release_contributor') ) {
       $('#phila_template_select option').each( function () {
         if( $(this).val() === 'press_release' ){
           $(this).css('display', 'inline-block');
         }
       });
-      $("#phila_template_select").val('post');
     }
+    
     if( phila_WP_User.includes( 'secondary_action_guide_editor' ) ) {
       $('#phila_template_select option').each( function () {
         if( $(this).val() === 'action_guide' ){
@@ -141,6 +150,7 @@ jQuery(document).ready(function($){
         }
       });
     }
+
 
   }
   if ( ( typenow == 'department_page') && adminpage.indexOf('post') > -1 ){

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-standard-metaboxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-standard-metaboxes.php
@@ -1007,6 +1007,21 @@ public static function phila_meta_var_connect(){
             'desc' => '(###)-###-####',
           ),
           array(
+            'name' => 'More phone numbers' ,
+            'id'   => 'phila_connect_phone_multi',
+            'type' => 'group',
+            'clone' => true,
+            'add_button'  => '+ Add another number',
+            'fields'  => array(
+              array(
+                'id'   => 'phila_connect_phone',
+                'type' => 'phone',
+                'desc' => '(###)-###-####',
+              ),
+            ),
+
+          ),
+          array(
             'name' => 'Fax',
             'id'   => 'phila_connect_fax',
             'type' => 'phone',

--- a/wp/wp-content/themes/phila.gov-theme/functions.php
+++ b/wp/wp-content/themes/phila.gov-theme/functions.php
@@ -1490,6 +1490,20 @@ function phila_connect_panel($connect_panel) {
     'subscriber-number' => isset( $connect_panel['phila_connect_general']['phila_connect_phone']['phone-subscriber-number'] ) ? $connect_panel['phila_connect_general']['phila_connect_phone']['phone-subscriber-number']  : '',
     );
 
+    if ( isset( $connect_panel['phila_connect_general']['phila_connect_phone_multi']) ) {
+
+      foreach ( $connect_panel['phila_connect_general']['phila_connect_phone_multi'] as $key => $value ) {
+
+        $output_array['phone_multi'][$key] = array(
+          'area' => isset( $connect_panel['phila_connect_general']['phila_connect_phone_multi'][$key]['phila_connect_phone']['area'] ) ? $connect_panel['phila_connect_general']['phila_connect_phone_multi'][$key]['phila_connect_phone']['area'] : '',
+    
+          'co-code' => isset( $connect_panel['phila_connect_general']['phila_connect_phone_multi'][$key]['phila_connect_phone']['phone-co-code'] ) ? $connect_panel['phila_connect_general']['phila_connect_phone_multi'][$key]['phila_connect_phone']['phone-co-code'] : '',
+    
+        'subscriber-number' => isset( $connect_panel['phila_connect_general']['phila_connect_phone_multi'][$key]['phila_connect_phone']['phone-subscriber-number'] ) ? $connect_panel['phila_connect_general']['phila_connect_phone_multi'][$key]['phila_connect_phone']['phone-subscriber-number']  : '',
+        );
+      }
+    }
+
     $output_array['fax'] =
       isset( $connect_panel['phila_connect_general']['phila_connect_fax'] ) && is_array( $connect_panel['phila_connect_general']['phila_connect_fax'] ) ? $connect_panel_fax = '(' . $connect_panel['phila_connect_general']['phila_connect_fax']['area'] . ') ' . $connect_panel['phila_connect_general']['phila_connect_fax']['phone-co-code'] . '-' . $connect_panel['phila_connect_general']['phila_connect_fax']['phone-subscriber-number'] : '' ;
 

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/v2/content-connect.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/v2/content-connect.php
@@ -78,6 +78,23 @@
           <span class="type <?php echo ( !$connect_vars['fax'] ) ? 'accessible' : '';?>">Phone: </span>
           <a href="tel:<?php echo preg_replace('/[^A-Za-z0-9]/', '', $full_phone); ?>" class="value phone-link"><?php echo $full_phone; ?></a>
         </div>
+        <?php if (isset($connect_vars['phone_multi'])): ?>
+          <?php foreach ($connect_vars['phone_multi'] as $phone_multi) : ?>
+          <div class="p-tel">
+            <?php
+            $area = ( $phone_multi['area'] != '' ) ? '(' .  $phone_multi['area'] . ') ' : '';
+
+            $co_code = ( $phone_multi['co-code'] != '' ) ? $phone_multi['co-code'] : '';
+
+            $subscriber_number = ( $phone_multi['subscriber-number'] != '' ) ? '-' . $phone_multi['subscriber-number'] : '';
+
+            $full_phone_2 = $area . $co_code . $subscriber_number;
+            ?>
+            <span class="type <?php echo ( !$connect_vars['fax'] ) ? 'accessible' : '';?>">Alternate phone: </span>
+            <a href="tel:<?php echo preg_replace('/[^A-Za-z0-9]/', '', $full_phone_2); ?>" class="value phone-link"><?php echo $full_phone_2; ?></a>
+          </div>
+          <?php endforeach; ?>
+        <?php endif; ?>
       <?php if ( !$connect_vars['fax'] == '') : ?>
         <div class="fax">
           <span class="type">Fax: </span><span class="value"><?php echo $connect_vars['fax']; ?></span>


### PR DESCRIPTION
Correct admin issue where "post" template is automatically selected when a user with permissions to multiple post types edits existing content. 

Add new field for multiple phone numbers in a connect box. 