### PR TITLE
Correct header on transition pages

### DIFF
--- a/wp/wp-content/themes/phila.gov-theme/functions.php
+++ b/wp/wp-content/themes/phila.gov-theme/functions.php
@@ -253,8 +253,8 @@ function phila_open_graph() {
     $alt_text = get_post_meta( $img_id, '_wp_attachment_image_alt', true );
   } elseif ( get_post_type($post->ID) == 'programs' ){
     $img = rwmb_meta('prog_header_img', array('limit' => 1), $post->ID );
-    $img_src = $img[0]['full_url'];
-    $alt_text = $img[0]['alt'];
+    $img_src = !empty($img) ? $img[0]['full_url'] : '';
+    $alt_text = !empty( $img ) ? $img[0]['alt'] : '';
   } elseif ( get_post_type($post->ID) == 'event_spotlight' ){
     $img = rwmb_meta('header_img', array('limit' => 1), $post->ID );
     $img_src = $img[0]['full_url'];

--- a/wp/wp-content/themes/phila.gov-theme/inc/breadcrumbs.php
+++ b/wp/wp-content/themes/phila.gov-theme/inc/breadcrumbs.php
@@ -102,7 +102,7 @@ function phila_breadcrumbs() {
         $output = '<li><a href="'.get_permalink($ancestor).'" title="'.get_the_title($ancestor).'">'.get_the_title($ancestor).'</a></li> ' .  $output;
       }
 
-      echo '<li><a href="/programs">Programs and initiatives</a></li>' . $output;
+      echo '<li><a href="/programs-initiatives/">Programs and initiatives</a></li>' . $output;
       echo '<li> '.$title.'</li>';
     } elseif ( is_singular('guides') ) {
 
@@ -119,7 +119,7 @@ function phila_breadcrumbs() {
     } elseif ( is_page() || get_post_type() == 'service_page') {
 
       if ( get_post_type() == 'service_page') {
-        echo '<li><a href="/services">' . __( 'Services', 'phila.gov' ) . '</a></li>';
+        echo '<li><a href="/service-directory/">' . __( 'Services', 'phila.gov' ) . '</a></li>';
       }
 
       if( $post->post_parent ){

--- a/wp/wp-content/themes/phila.gov-theme/partials/programs/header.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/programs/header.php
@@ -24,7 +24,7 @@
   $credit = rwmb_meta( 'phila_photo_credit' );
   $description = rwmb_meta( 'phila_meta_desc' );
 
-  $current_post_type = get_post_type($post);
+  $current_post_type = get_post_type($post->ID);
 ?>
 <header>
   <?php if ( !empty( get_post_ancestors( $post->ID ) ) ) : ?>
@@ -32,6 +32,7 @@
       <div class="grid-container pvxl">
         <div class="grid-x center">
           <div class="cell">
+    
             <?php if(!empty($sub_heading)) : ?>
               <hr>
             <?php endif ?>
@@ -49,19 +50,22 @@
     <?php if (phila_get_selected_template() != 'prog_association') : ?>
       <?php phila_get_menu(); ?>
     <?php endif; ?>
+    <?php if ($current_post_type != 'department_page') : ?>
       <div class="mtl mbm">
         <?php get_template_part( 'partials/breadcrumbs' ); ?>
       </div>
-    <?php if ( empty( $sub_heading ) ) :?>
-      <div class="grid-container">
-        <div class="grid-x">
-          <div class="cell">
-            <h2 class="contrast"><?php echo the_title(); ?></h2>
+      <?php if ( empty( $sub_heading ) ) :?>
+        <div class="grid-container">
+          <div class="grid-x">
+            <div class="cell">
+              <h2 class="contrast"><?php echo the_title(); ?></h2>
+            </div>
           </div>
         </div>
-      </div>
+      <?php endif; ?>
     <?php endif; ?>
-  <?php else: ?>
+
+    <?php elseif($current_post_type !== 'department_page'): ?>
     <div class="hero-half">
       <div class="grid-x">
         <div class="cell medium-12 bg-shade bg-ben-franklin-blue white hero-half--container">

--- a/wp/wp-content/themes/phila.gov-theme/single-department_page.php
+++ b/wp/wp-content/themes/phila.gov-theme/single-department_page.php
@@ -99,7 +99,7 @@ get_header(); ?>
               <?php wp_reset_query(); ?>
             <?php endif; ?>
             <!-- END Department Stub -->
-        <?php }else{
+        <?php } else {
           $is_stub = false;
           include(locate_template( 'templates/single-on-site-content.php') ) ;
         }

--- a/wp/wp-content/themes/phila.gov-theme/templates/single-on-site-content.php
+++ b/wp/wp-content/themes/phila.gov-theme/templates/single-on-site-content.php
@@ -24,7 +24,7 @@ $user_selected_template    = phila_get_selected_template();
 
   <?php if ($user_selected_template == 'programs_initiatives') : ?>
     <?php get_template_part( 'partials/departments/content', 'programs-initiatives-header' ); ?>
-  <?php else : ?>
+  <?php elseif ($user_selected_template != 'prog_association'): ?>
     <header class="row">
       <div class="columns">
         <?php the_title( '<h2 class="sub-page-title contrast">', '</h2>' ); ?>


### PR DESCRIPTION
Ensure hero headers are appearing in the correct locations. Fixes warning in `page with association` twitter images. 