### PR TITLE
Allow subpage with association to have one level deep of children

### DIFF
--- a/wp/wp-content/themes/phila.gov-theme/partials/programs/header.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/programs/header.php
@@ -11,6 +11,13 @@
 
   $sub_heading = rwmb_meta('prog_sub_head');
 
+  if (isset($association)) {
+    $parent = wp_get_post_parent_id($post);
+    $sub_hero = rwmb_meta( 'prog_association_img', array( 'limit' => 1 ), $parent);
+
+    $sub_heading = rwmb_meta('prog_sub_head', array(), $parent);
+  }
+
   if ( !empty( $sub_hero ) ):
     $sub_hero = reset( $sub_hero );
   else:
@@ -25,9 +32,10 @@
   $description = rwmb_meta( 'phila_meta_desc' );
 
   $current_post_type = get_post_type($post->ID);
+
 ?>
 <header>
-  <?php if ( !empty( get_post_ancestors( $post->ID ) ) ) : ?>
+  <?php if ( $user_selected_template === 'prog_association' ) : ?>
     <div class="hero-subpage <?php echo !empty($sub_heading) ? 'associated-sub' : '' ?>" style="background-image:url(<?php echo $sub_hero['full_url']  ?>) ">
       <div class="grid-container pvxl">
         <div class="grid-x center">
@@ -47,7 +55,7 @@
         </div>
       </div>
     </div>
-    <?php if (phila_get_selected_template() != 'prog_association') : ?>
+    <?php if ($user_selected_template != 'prog_association') : ?>
       <?php phila_get_menu(); ?>
     <?php endif; ?>
     <?php if ($current_post_type != 'department_page' && $user_selected_template != 'stub') : ?>

--- a/wp/wp-content/themes/phila.gov-theme/single-department_page.php
+++ b/wp/wp-content/themes/phila.gov-theme/single-department_page.php
@@ -26,9 +26,16 @@ $children = get_posts( array(
 ));
 
 $ancestors = get_post_ancestors($post);
+$parent = wp_get_post_parent_id($post);
 $user_selected_template = phila_get_selected_template();
 
+if (phila_get_selected_template($parent) == 'prog_association' ) {
+  $user_selected_template = 'prog_association';
+  $association = true;
+}
+
 get_header(); ?>
+
 
 <div id="post-<?php the_ID(); ?>" <?php post_class('department clearfix'); ?>>
 
@@ -55,7 +62,8 @@ get_header(); ?>
 
 ?>
 <?php else: ?>
-    <?php include(locate_template( 'partials/programs/header.php') ); ?>
+    <?php 
+      include(locate_template( 'partials/programs/header.php') ); ?>
 <?php endif; ?>
 
 


### PR DESCRIPTION
Currently subpages with association are a template the users selects manually and a different header is applied only to that page. This PR checks if a child of a subpage with association has a parent of that template type, and if so, it applies the header from the parent page, instead of it's grandparent page (which would be the standard department or program header). This only works one level deep, currently. 
```
Parent page - department homepage
-- child page - subpage with association header 
---- grandchild page - now gets subpage with association header 
----- great grandchild page -  would revert to department homepage header
-- regular child page -  no change
```
