### PR TITLE
Adjust template for stepped content + clean up accordion rendering

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-row-metaboxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-row-metaboxes.php
@@ -674,7 +674,9 @@ class Phila_Gov_Row_Metaboxes {
         'id'  => 'phila_stepped_select',
         'type'  => 'switch',
         'on_label'  => 'Yes',
-        'off_label' => 'No'
+        'off_label' => 'No',
+        'hidden' => array('phila_template_select', '=', 'custom_content'),
+
       ),
       array(
         'id' => 'phila_stepped_content',

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-row-metaboxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-row-metaboxes.php
@@ -19,7 +19,6 @@ class Phila_Gov_Row_Metaboxes {
       Phila_Gov_Row_Select_Options::phila_metabox_grid_options(),
       Phila_Gov_Row_Metaboxes::phila_metabox_full_options(),
       Phila_Gov_Row_Select_Options::phila_metabox_thirds_options(),
-      Phila_Gov_Row_Select_Options::phila_metabox_half_options(),
       ),
     );
   }
@@ -493,71 +492,6 @@ class Phila_Gov_Row_Metaboxes {
         ),
       );
     }
-
-   // 1/2 x 1/2: Column 1 Options
-  public static function phila_metabox_half_option_one( ){
-    return array(
-    'id' => 'phila_half_col_1',
-    'type' => 'group',
-    'fields' => array(
-        array(
-          'name' => 'Column 1 <br/><small>(1/2 width column)</small>',
-          'id'   => 'phila_half_col_1_option',
-          'desc'  => 'Choose to display recent blog posts or custom markup text.',
-          'type' => 'select',
-          'placeholder' => 'Select...',
-          'options' => array(
-            'phila_custom_text' => 'Custom Text',
-            'phila_pullquote' => 'Pullquote',
-            ),
-        ),
-        array(
-          'id'   => 'phila_custom_text',
-          'type' => 'group',
-          'visible' => array('phila_half_col_1_option', '=', 'phila_custom_text'),
-          'fields' => Phila_Gov_Standard_Metaboxes::phila_metabox_v2_wysiwyg_upgraded(),
-        ),
-        array(
-          'id'   => 'phila_pullquote',
-          'type' => 'group',
-          'visible' => array('phila_half_col_1_option', '=', 'phila_pullquote'),
-          'fields' => Phila_Gov_Standard_Metaboxes::phila_meta_var_pullquote(),
-        ),
-      ),
-    );
-  }
-   // 1/2 x 1/2: Column 1 Options
-    public static function phila_metabox_half_option_two( ){
-    return array(
-      'id' => 'phila_half_col_2',
-      'type' => 'group',
-      'fields' => array(
-        array(
-          'name' => 'Column 2 <br/><small>(1/2 width column)</small>',
-          'id'   => 'phila_half_col_2_option',
-          'desc'  => 'Choose to display recent blog posts or custom markup text.',
-          'type' => 'select',
-          'placeholder' => 'Select...',
-          'options' => array(
-            'phila_custom_text' => 'Custom Text',
-            'phila_pullquote' => 'Pullquote',
-            ),
-        ),
-        array(
-          'id'   => 'phila_custom_text',
-          'type' => 'group',
-          'visible' => array('phila_half_col_2_option', '=', 'phila_custom_text'),
-          'fields' => Phila_Gov_Standard_Metaboxes::phila_metabox_v2_wysiwyg_upgraded(),
-        ),
-        array(
-          'id'   => 'phila_pullquote',
-          'type' => 'group',
-          'visible' => array('phila_half_col_2_option', '=', 'phila_pullquote'),
-          'fields' => Phila_Gov_Standard_Metaboxes::phila_meta_var_pullquote(),
-        ),
-      ),
-    );
-  }
 
   public static function phila_metabox_photo_callout( ){
       return  array(

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-row-select-options.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-row-select-options.php
@@ -20,7 +20,6 @@ class Phila_Gov_Row_Select_Options {
     'placeholder' => 'Select...',
     'options' => array(
       'phila_grid_options_full' => 'Full Width',
-      'phila_grid_options_half' => '1/2 x 1/2',
       'phila_grid_options_thirds' => '2/3 x 1/3',
       ),
     );
@@ -82,24 +81,6 @@ class Phila_Gov_Row_Select_Options {
       'fields' => array(
         Phila_Gov_Row_Metaboxes::phila_metabox_thirds_option_one(),
         Phila_Gov_Row_Metaboxes::phila_metabox_thirds_option_two(),
-      ),
-    );
-  }
-
-  public static function phila_metabox_half_options( ){
-
-    return array(
-      'name' => '1/2 x 1/2 Options',
-      'id'   => 'phila_half_options',
-      'type' => 'group',
-      'hidden' => array(
-        'phila_grid_options',
-        '!=',
-        'phila_grid_options_half'
-      ),
-      'fields' => array(
-        Phila_Gov_Row_Metaboxes::phila_metabox_half_option_one(),
-        Phila_Gov_Row_Metaboxes::phila_metabox_half_option_two(),
       ),
     );
   }

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-standard-metaboxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-standard-metaboxes.php
@@ -182,7 +182,7 @@ class Phila_Gov_Standard_Metaboxes {
           'id'  => 'phila_stepped_select',
           'type'  => 'switch',
           'on_label'  => 'Yes',
-          'off_label' => 'No'
+          'off_label' => 'No',
         ),
         array(
           'id' => 'phila_stepped_content',

--- a/wp/wp-content/themes/phila.gov-theme/css/scss/_accordion.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/_accordion.scss
@@ -24,3 +24,7 @@
 .accordion.commissions div{
   text-transform: none;
 }
+
+.no-p-margin p{
+  margin-bottom: 0;
+}

--- a/wp/wp-content/themes/phila.gov-theme/partials/content-custom-prereq-row.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/content-custom-prereq-row.php
@@ -2,7 +2,7 @@
   ?>
   <section>
     <div class="mbxxl">
-      <h3 id="<?php echo sanitize_title_with_dashes($requirements_prereq_title) ?>" class="phm-mu mtl mbm"><?php echo $requirements_prereq_title ?></h3>
+      <h3 id="<?php echo sanitize_title_with_dashes($requirements_prereq_title) ?>" class="mtl mbm"><?php echo $requirements_prereq_title ?></h3>
       <?php
         $accordion_title = '';
         $is_full_width = false; 

--- a/wp/wp-content/themes/phila.gov-theme/partials/content-single-heading-group.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/content-single-heading-group.php
@@ -5,30 +5,39 @@
  */
 ?>
 
-<?php $is_address = isset($current_row['phila_full_options']['phila_content_heading_group']['phila_address_select']) ? $current_row['phila_full_options']['phila_content_heading_group']['phila_address_select'] : ''; ?>
-<?php $stepped_select = isset($current_row['phila_full_options']['phila_content_heading_group']['phila_stepped_select']) ? $current_row['phila_full_options']['phila_content_heading_group']['phila_stepped_select'] : ''; ?>
-<?php $contact_content = isset($current_row['phila_full_options']['phila_content_heading_group']['phila_std_address']) ? $current_row['phila_full_options']['phila_content_heading_group']['phila_std_address'] : ''; ?>
+<?php $is_address = isset($current_row['phila_full_options']['phila_content_heading_group']['phila_address_select']) ? $current_row['phila_full_options']['phila_content_heading_group']['phila_address_select'] : ''; 
+?>
+<?php $stepped_select = isset($current_row['phila_full_options']['phila_content_heading_group']['phila_stepped_select']) ? $current_row['phila_full_options']['phila_content_heading_group']['phila_stepped_select'] : '';
+?>
 
-<div class="grid-container">
-  <div class="grid-x mvl">
-    <div class="cell">
-      <section>
-        <?php if ($wysiwyg_heading != '') : ?>
-          <h3 class="black bg-ghost-gray phm-mu mbm" id="<?php echo sanitize_title_with_dashes($wysiwyg_heading, null, 'save') ?>"><?php echo $wysiwyg_heading; ?></h3>
-        <?php endif; ?>
-        <div class="phm-mu">
-          <?php if ((!empty($wysiwyg_content) || (!empty($is_address)))) : ?>
-            <?php echo apply_filters('the_content', $wysiwyg_content); ?>
-            <?php include(locate_template('partials/global/contact-information.php')); ?>
-          <?php endif ?>
-          <?php if (!empty($stepped_select)) : ?>
-            <?php $steps = phila_extract_stepped_content($stepped_select); ?>
-            <div class="phm-mu">
-              <?php include(locate_template('partials/stepped-content.php')); ?>
-            </div>
+<?php $contact_content = isset($current_row['phila_full_options']['phila_content_heading_group']['phila_std_address']) ? $current_row['phila_full_options']['phila_content_heading_group']['phila_std_address'] : ''; 
+
+$source_template =  rwmb_meta( 'phila_template_select'); 
+?>
+<?php if ($source_template !== 'custom_content') : ?>
+  <div class="grid-container">
+<?php endif; ?>
+<div class="grid-x mvl">
+  <div class="cell">
+    <section>
+      <?php if ($wysiwyg_heading != '') : ?>
+        <h3 class="black bg-ghost-gray phm-mu mbm" id="<?php echo sanitize_title_with_dashes($wysiwyg_heading, null, 'save') ?>"><?php echo $wysiwyg_heading; ?></h3>
+      <?php endif; ?>
+      <div class="phm-mu">
+        <?php if ((!empty($wysiwyg_content) || (!empty($is_address)))) : ?>
+          <?php echo apply_filters('the_content', $wysiwyg_content); ?>
+          <?php include(locate_template('partials/global/contact-information.php')); ?>
+        <?php endif ?>
+        <?php if (!empty($stepped_select)) :
+          $steps = phila_extract_stepped_content($current_row['phila_full_options']['phila_content_heading_group']['phila_stepped_content']);?>
+          <div class="phm-mu">
+            <?php include(locate_template('partials/stepped-content.php')); ?>
+          </div>
           <?php endif; ?>
-        </div>
-      </section>
-    </div>
+      </div>
+    </section>
   </div>
 </div>
+<?php if ($source_template !== 'custom_content') : ?>
+</div>
+<?php endif; ?>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
@@ -14,8 +14,8 @@
   $page_rows = rwmb_meta('phila_row');
 ?>
 <?php if (!phila_util_is_array_empty($page_rows)): ?>
-  <!-- Program and initiatives -->
-  <section>
+<!-- /Page content / programs + initiatives -->
+<section>
   <?php
     foreach ($page_rows as $key => $value):
       $current_row = $page_rows[$key];?>
@@ -322,54 +322,6 @@
 
         <?php endif;  /*end full row */?>
 
-        <?php elseif ( ( isset( $current_row['phila_grid_options'] ) && $current_row['phila_grid_options'] == 'phila_grid_options_half') && ( isset( $current_row['phila_half_options']['phila_half_col_1'] ) && isset( $current_row['phila_half_options']['phila_half_col_2'] ) ) ):
-
-          // Begin 1/2 x 1/2 row
-          $current_row_option_one = $current_row['phila_half_options']['phila_half_col_1'];
-          $current_row_option_two = $current_row['phila_half_options']['phila_half_col_2']; ?>
-
-        <section class="row mvl">
-          <?php if ( $current_row_option_one['phila_half_col_1_option'] == 'phila_custom_text'):?>
-
-            <?php if ( isset( $current_row_option_one['phila_custom_text'] ) ):
-              $custom_text = $current_row_option_one['phila_custom_text']; ?>
-              <div class="large-12 columns">
-                <?php include(locate_template('partials/departments/content-custom-text.php'));?>
-              </div>
-            <?php endif;?>
-
-          <?php elseif ( $current_row_option_one['phila_half_col_1_option'] == 'phila_pullquote'):
-            $pullquote = isset ($current_row_option_one['phila_pullquote'] ) ? $current_row_option_one['phila_pullquote'] : '';
-            $quote = isset( $pullquote['phila_quote'] ) ? $pullquote['phila_quote'] : '';
-            $attribution = isset( $pullquote['phila_attribution'] ) ? $pullquote['phila_attribution'] : '';
-
-            if ( !empty( $quote ) ): ?>
-              <div class="large-12 columns">
-                <?php echo do_shortcode('[pullquote quote="' . $quote . '" attribution="' . $attribution . '" inline="false"]'); ?>
-              </div>
-            <?php endif; ?>
-          <?php endif; ?>
-
-          <?php if ( $current_row_option_two['phila_half_col_2_option'] == 'phila_custom_text'):?>
-              <?php if ( isset( $current_row_option_two['phila_custom_text'] ) ):
-                $custom_text = $current_row_option_two['phila_custom_text'];?>
-                <div class="large-12 columns">
-                  <?php include(locate_template('partials/departments/content-custom-text.php'));?>
-                </div>
-              <?php endif;?>
-
-          <?php elseif ( $current_row_option_two['phila_half_col_2_option'] == 'phila_pullquote'):
-            $pullquote = isset ($current_row_option_two['phila_pullquote'] ) ? $current_row_option_two['phila_pullquote'] : '';
-            $quote = isset( $pullquote['phila_quote'] ) ? $pullquote['phila_quote'] : '';
-            $attribution = isset( $pullquote['phila_attribution'] ) ? $pullquote['phila_attribution'] : '';
-
-            if ( !empty( $quote ) ): ?>
-              <div class="large-12 columns">
-                <?php echo do_shortcode('[pullquote quote="' . $quote . '" attribution="' . $attribution . '" inline="false"]'); ?>
-              </div>
-            <?php endif; ?>
-          <?php endif; ?>
-
       </section>
       <?php elseif ( (isset( $current_row['phila_grid_options'] ) && $current_row['phila_grid_options'] == 'phila_grid_options_thirds' ) && ( isset($current_row['phila_two_thirds_options']['phila_two_thirds_col'] ) && isset( $current_row['phila_two_thirds_options']['phila_one_third_col'] ) ) ):
 
@@ -412,5 +364,5 @@
       <?php endif; ?>
     <?php endforeach; ?>
   </div>
-<!-- /Program and initiatives -->
+<!-- /Page content / programs + initiatives -->
 <?php endif; ?>

--- a/wp/wp-content/themes/phila.gov-theme/partials/global/accordion.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/global/accordion.php
@@ -27,17 +27,17 @@
   <?php foreach ( $accordion_group as $ag_key => $accordion ) : ?>
   <?php reset($accordion_group) ?>
   <div class="icon-expand-container result">
-    <div class="icon-expand-title grid-x">
+    <div class="icon-expand-title grid-x align-middle">
       <?php if ($use_icon === true ) :?>
         <?php if ( isset( $accordion['phila_custom_wysiwyg']['phila_accordion_icon'] ) ) { ?>
-            <div class="cell shrink mrm mtxs"><i class="<?php echo $accordion['phila_custom_wysiwyg']['phila_accordion_icon'] ?> fa-2x"></i></div> 
-        <?php } else if (isset($custom_icon ) && $custom_icon === true ) { ?>          
-            <div class="cell shrink mrm mtxs"><i class="<?php echo rwmb_meta('phila_v2_icon') ?> fa-2x"></i></div> 
+            <div class="cell shrink mrm mtxs"><i class="<?php echo $accordion['phila_custom_wysiwyg']['phila_accordion_icon'] ?> fa-2x fa-fw"></i></div> 
+        <?php } else if ( isset( $custom_icon ) && $custom_icon === true ) { ?>          
+            <div class="cell shrink mrm mtxs"><i class="<?php echo rwmb_meta('phila_v2_icon') ?> fa-2x fa-fw"></i></div> 
         <?php } else { ?>
-          <div class="cell shrink mrm mtxs"><i class="fas fa-tasks fa-2x"></i></div> 
+          <div class="cell shrink mrl mtxs"><i class="fas fa-tasks fa-2x fa-fw"></i></div> 
         <?php } ?>
       <?php endif; ?>
-      <div class="cell auto">
+      <div class="cell auto no-p-margin">
         <?php echo apply_filters( 'the_content', $accordion['phila_custom_wysiwyg']['phila_wysiwyg_title'] ); ?>
       </div>
     </div>


### PR DESCRIPTION
This PR does a couple of things:
- Hides the stepped content option for heading groups appearing on the "custom_content" template 
    - Corrects the code so if we ever wanted that option back, it would work
 - Removes very old 1/2 1/2 template options that are no longer in use 

Tested on the following service templates: 
- Default
- Default (2020)
- Generic (old default)

Also tested on program homepage template. 