### PR TITLE
updated media

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/public/controllers/class-phila-longform-content.php
+++ b/wp/wp-content/plugins/phila.gov-customization/public/controllers/class-phila-longform-content.php
@@ -271,11 +271,6 @@ class Phila_Longform_Content_Controller {
           'type'        => 'string',
           'readonly'    => true,
         ),
-        // 'dateFormatted' => array(
-        //   'description' => esc_html__('dateFormatted of the document.', 'phila-gov'),
-        //   'type'        => 'string',
-        //   'readonly'    => true,
-        // ),
         'editLink'  => array(
           'description' => esc_html__('editLink of the document.', 'phila-gov'),
           'type'        => 'string',

--- a/wp/wp-includes/media.php
+++ b/wp/wp-includes/media.php
@@ -3977,6 +3977,12 @@ function wp_prepare_attachment_for_js( $attachment ) {
 	$attachment_url = wp_get_attachment_url( $attachment->ID );
 	$base_url       = str_replace( wp_basename( $attachment_url ), '', $attachment_url );
 
+	$document_published = rwmb_meta( 'phila_document_page_release_date', $args = array(), $post_id = $attachment->ID );	
+
+	if ( empty($document_published) ){	
+		$document_published = get_the_date( $d = '', $attachment->ID );	
+	}
+
 	$response = array(
 		'id'            => $attachment->ID,
 		'title'         => $attachment->post_title,
@@ -3997,7 +4003,7 @@ function wp_prepare_attachment_for_js( $attachment ) {
 		'type'          => $type,
 		'subtype'       => $subtype,
 		'icon'          => wp_mime_type_icon( $attachment->ID ),
-		'dateFormatted' => mysql2date( __( 'F j, Y' ), $attachment->post_date ),
+		'dateFormatted' => $document_published,
 		'nonces'        => array(
 			'update' => false,
 			'delete' => false,


### PR DESCRIPTION
To test - 
1. pull this repo locally 
2. pull the year-only branch from the doc finder repo https://github.com/CityOfPhiladelphia/document-finder/tree/year-only
2. run the document finder with the following ID's in your .env.local file one at a time

Document finder date testing
211256 - ID for just year
71348 - ID for full date
