### PR TITLE
add link text to modals in full page call to action

### DIFF
--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/v2/full-width-call-to-action.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/v2/full-width-call-to-action.php
@@ -37,8 +37,10 @@
                     <?php echo $link['link_text']?>
                   </span>
                 <?php elseif (!empty( $link['modal_icon'] ) ) :?>
+                  <span class="button-label valign-cell">
+                    <?php echo $link['link_text']?>
+                </span>
                   <i class="fa <?php echo $link['modal_icon'] ?> valign-cell" aria-hidden="true"></i>
-                  <span class="accessible">Open modal</span>
                 <?php else :?>
                   <span class="valign-cell">
                     <?php echo $link['link_text']?>


### PR DESCRIPTION
this is a fix for this wrike ticket https://www.wrike.com/workspace.htm?acc=2747306#path=folder&id=432990175&c=board&vid=3978741&p=489051602&a=2747306&ot=771879604&so=10&bso=10&sd=0&f=&st=space-453350584