### PR TITLE
Separate announcements into its own component

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-row-metaboxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-row-metaboxes.php
@@ -103,6 +103,22 @@ class Phila_Gov_Row_Metaboxes {
         ),
       ),
       array(
+        'visible' => array('phila_full_options_select', '=', 'phila_announcements'),
+        'id'  => 'phila_announcements_group',
+        'type' => 'group',
+        'fields' => array(
+          Phila_Gov_Standard_Metaboxes::phila_metabox_category_picker('Select new owner', 'phila_ann_category', 'Display announcements from these owners.' ),
+          array(
+            'name'  => 'Filter by a tag',
+            'id'  => 'tag',
+            'type' => 'taxonomy_advanced',
+            'taxonomy'  => 'ann_tag',
+            'field_type' => 'select_advanced',
+            'desc'  => 'Display announcements using this tag.'
+          ),
+        ),
+      ),
+      array(
         'id' => 'phila_full_width_calendar',
         'type' => 'group',
         'visible' => array('phila_full_options_select', '=', 'phila_full_width_calendar'),

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-row-select-options.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-row-select-options.php
@@ -34,6 +34,7 @@ class Phila_Gov_Row_Select_Options {
       'placeholder' => 'Select full-width row module...',
       'options' => array(
         'phila_content_additional_content' => 'Additional Content',
+        'phila_announcements' => 'Announcements',
         'phila_blog_posts' => 'Blog posts',
         'phila_board_commission'  => 'Board or commission members',
         'phila_full_width_calendar' => 'Calendar',

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/meta-boxes.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/meta-boxes.php
@@ -630,7 +630,7 @@ function phila_register_meta_boxes( $meta_boxes ){
           'relation' => 'or',
         ),
         'fields' => array(
-          Phila_Gov_Standard_Metaboxes::phila_metabox_category_picker('Select owners', 'phila_post_category', 'Display posts from these owners. This will override page ownership selection entirely.'),
+          Phila_Gov_Standard_Metaboxes::phila_metabox_category_picker('Select owners', 'phila_post_category', 'Display posts from these owners. This will override page ownership selection.'),
           array(
             'name'  => 'Filter by a tag',
             'id'  => 'tag',
@@ -640,6 +640,57 @@ function phila_register_meta_boxes( $meta_boxes ){
             'desc'  => 'Display posts using this tag. "See all" will pre-filter on these terms.'
           ),
           Phila_Gov_Standard_Metaboxes::phila_metabox_url('See all link override', 'override_url', '', 12 ),
+        ),
+      ),
+    ),
+  );
+
+  $meta_boxes[] = array(
+    'id'       => 'phila_full_row_announcements',
+    'title'    => 'Full row announcements',
+    'pages'    => array( 'department_page', 'guides' ),
+    'context'  => 'normal',
+    'priority' => 'high',
+
+    'include' => array(
+      'user_role'  => array( 'administrator', 'primary_department_homepage_editor', 'editor' ),
+    ),
+
+    'visible' => array(
+      'when' => array(
+        array( 'phila_template_select', '=', 'homepage_v2' ),
+        array( 'phila_template_select', '=', 'guide_landing_page' )
+      ),
+      'relation' => 'or', 
+    ),
+
+    'fields' => array(
+      array(
+        'name' => 'Display a full row of announcements?',
+        'id'   => 'phila_full_row_announcements_selected',
+        'type' => 'switch',
+        'on_label'  => 'Yes',
+        'off_label' => 'No',
+      ),
+      array(
+        'id'  => 'phila_get_ann_cats',
+        'type' => 'group',
+        'visible' => array(
+          'when' => array(
+            array( 'phila_full_row_announcements_selected', '=', 1 ),
+          ),
+          'relation' => 'or',
+        ),
+        'fields' => array(
+          Phila_Gov_Standard_Metaboxes::phila_metabox_category_picker('Select owners', 'phila_announcement_category', 'Display announcements from these owners. This will override page ownership selection.'),
+          array(
+            'name'  => 'Filter by a tag',
+            'id'  => 'announcements_tag',
+            'type' => 'taxonomy_advanced',
+            'taxonomy'  => 'post_tag',
+            'field_type' => 'select_advanced',
+            'desc'  => 'Display announcements using this tag.'
+          ),
         ),
       ),
     ),

--- a/wp/wp-content/themes/phila.gov-theme/css/scss/pages/_staff-directory.scss
+++ b/wp/wp-content/themes/phila.gov-theme/css/scss/pages/_staff-directory.scss
@@ -76,3 +76,8 @@
     text-transform: lowercase;
   }
 }
+.single-department_page {
+  .staff-directory {
+    padding-top: 3rem;
+  }
+}

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/content-programs-initiatives.php
@@ -15,7 +15,7 @@
 
 ?>
 <?php if (!phila_util_is_array_empty($page_rows)): ?>
-<!-- /Page content / programs + initiatives -->
+<!-- Page content -->
 <section>
   <?php
     foreach ($page_rows as $key => $value):
@@ -36,6 +36,12 @@
           </div>
           <!-- /Blog Content -->
 
+          <?php elseif ( $current_row_option === 'phila_announcements' ): ?>
+          <!-- Announcement Content -->
+            <?php $ann_cat_override = isset( $current_row['phila_full_options']['phila_announcements_group']['phila_ann_category']) ? $current_row['phila_full_options']['phila_announcements_group']['phila_ann_category'] : ''; ?>
+            <?php $blog_tag_override = isset( $current_row['phila_full_options']['phila_announcements_group']['ann_tag']) ? $current_row['phila_full_options']['phila_announcements_group']['ann_tag'] : ''; ?>
+            <?php include( locate_template( 'partials/global/phila_full_row_announcements.php' ) ); ?>
+          <!-- /Announcement Content -->
           <?php elseif ( $current_row_option == 'phila_full_width_calendar'):
             $cal_id = isset( $current_row['phila_full_options']['phila_full_width_calendar']['phila_full_width_calendar_id'] ) ? $current_row['phila_full_options']['phila_full_width_calendar']['phila_full_width_calendar_id'] : null;
             $spotlight_id = isset( $current_row['phila_full_options']['phila_full_width_calendar']['phila_event_spotlight'] ) ? $current_row['phila_full_options']['phila_full_width_calendar']['phila_event_spotlight'] : '';
@@ -369,5 +375,5 @@
       <?php endif; ?>
     <?php endforeach; ?>
   </div>
-<!-- /Page content / programs + initiatives -->
+<!-- /Page content -->
 <?php endif; ?>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/phila_full_row_announcements.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/phila_full_row_announcements.php
@@ -1,0 +1,9 @@
+<?php $ann_cats = rwmb_meta('phila_get_ann_cats');
+  $ann_cat_override = isset($ann_cats['phila_announcement_category']) ? $ann_cats['phila_announcement_category'] : '';
+  $ann_tag_override = isset($ann_override['ann_tag']) ? $ann_override['ann_tag'] : ''; ?>
+
+<!-- Announcement Content-->
+<section class="announcements">
+  <?php include(locate_template('partials/global/phila_full_row_announcements.php')); ?>
+</section>
+<!-- /Announcement Content-->

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/phila_full_row_blog.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/phila_full_row_blog.php
@@ -63,7 +63,6 @@
       $override_url = $a['see_all'];
     }
     
-    include( locate_template( 'partials/posts/announcements-grid.php' ) );
     include( locate_template( 'partials/posts/post-grid.php' ) );
   
     wp_reset_postdata();

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/v2/homepage_timeline.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/v2/homepage_timeline.php
@@ -22,6 +22,8 @@ $timeline_page = !isset($timeline_page) ? rwmb_meta('phila_select_timeline') : $
   }
 ?>
 
+<?php 
+if ( !empty($timeline_page) ) :?>
 <?php $temp_month = ''; ?>
 <?php 
   $date_type = $timeline_toggle == 'year' ? 'Y' : 'F Y';
@@ -108,3 +110,5 @@ $timeline_page = !isset($timeline_page) ? rwmb_meta('phila_select_timeline') : $
   </div>
 </section>
 <!-- Timeline Section/ -->
+
+<?php endif; ?>

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/v2/user_templates/homepage_v2.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/v2/user_templates/homepage_v2.php
@@ -31,9 +31,13 @@
             'shown' => true,
         ),
         'phila_full_row_blog'                    => array(
-                                                'type'=>'v1',
-                                                'shown'=>$this->full_row_blog['exists'],
-                                            ),
+                                                'type'=>'v2',
+                                                'shown' => true,
+                                              ),
+        'phila_full_row_announcements'       => array(
+                                                  'type'=>'v2',
+                                                  'shown' => true,
+                                                ),
         'full-width-call-to-action'      => array(
                                                 'type'=>'v2',
                                                 'shown'=>true

--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/v2/user_templates/homepage_v2.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/v2/user_templates/homepage_v2.php
@@ -31,13 +31,13 @@
             'shown' => true,
         ),
         'phila_full_row_blog'                    => array(
-                                                'type'=>'v2',
-                                                'shown' => true,
-                                              ),
+                                                'type'=>'v1',
+                                                'shown'=>$this->full_row_blog['exists'],
+        ),
         'phila_full_row_announcements'       => array(
-                                                  'type'=>'v2',
-                                                  'shown' => true,
-                                                ),
+                                                  'type'=>'v1',
+                                                  'shown'=>$this->full_row_announcements['exists'],
+                                            ),
         'full-width-call-to-action'      => array(
                                                 'type'=>'v2',
                                                 'shown'=>true

--- a/wp/wp-content/themes/phila.gov-theme/partials/global/phila_full_row_announcements.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/global/phila_full_row_announcements.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Standard template for a row of announcements
+ *
+ * @package phila-gov
+ */
+?>
+<?php
+
+  $categories = get_the_category();
+  if( !phila_util_is_array_empty($categories) ) {
+    $slang_name = phila_get_owner_typography( $categories[0] );
+  }
+
+  if ( !empty( $ann_cat_override )) :
+    if( is_object($ann_cat_override[0])) {
+      $slang_name = phila_get_owner_typography( $ann_cat_override[0] );
+    }
+    elseif( is_string($ann_cat_override[0])) {
+      $cat_cleaned = phila_cat_id_to_cat_name($ann_cat_override[0]);
+      $slang_name = phila_get_owner_typography( $cat_cleaned );
+    }
+
+  endif;
+
+  if ( empty($ann_tag_override) ) :
+    $ann_tag_override = '';
+  elseif( is_array( $ann_tag_override) ):
+    $ann_tag_override = implode(',', $ann_tag_override);
+  elseif (!empty($ann_tag_override)):
+    $ann_tag_override = $ann_tag_override;
+  endif;
+  ?>
+
+<section class="row">
+  <?php 
+    global $post;
+    $a = array(
+      'name' => 'Announcements',
+      'tag' => $ann_tag_override,
+    );
+  
+    if (isset($ann_cat_override[0])){
+      $category = array($ann_cat_override[0]);
+    } else {
+      $category = array();
+      $cats = get_the_category();
+      foreach ($cats as $cat) {
+        array_push($category, $cat->term_id);
+      }
+    }
+  
+    if ( !empty($a['tag'] ) ){
+      $tag = explode(',', $a['tag']);
+    }
+    
+    include( locate_template( 'partials/posts/announcements-grid.php' ) );
+  
+    wp_reset_postdata();
+  ?>
+</section>

--- a/wp/wp-content/themes/phila.gov-theme/partials/guides/landing-page.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/guides/landing-page.php
@@ -8,8 +8,13 @@
 
 $full_row_blog_selected =  rwmb_meta('phila_full_row_blog_selected');
 $full_row_blog = rwmb_meta('phila_full_row_blog');
+
+$full_row_ann_selected =  rwmb_meta('phila_full_row_announcements_selected');
+$full_row_ann = rwmb_meta('phila_full_row_announcements');
+
 $full_width_press_releases_selected = rwmb_meta('phila_full_row_press_releases_selected');
 $full_width_press_releases = rwmb_meta('phila_full_row_press_releases');
+
 $cal_id = rwmb_meta('phila_full_width_calendar_id');
 ?>
 <section>
@@ -39,9 +44,7 @@ $cal_id = rwmb_meta('phila_full_width_calendar_id');
         <div class="expandable show-all-on-desktop">
           <div class="intro-text" id="guides-intro-text"><?php the_content(); ?></div>
         </div>
-       
           <a href="#" data-toggle="expandable" class="float-right more-button"> More + </a>
-       
       </div>
     </div>
   <?php endif; ?>
@@ -96,6 +99,18 @@ $cal_id = rwmb_meta('phila_full_width_calendar_id');
   </div>
 
 </div>
+
+<?php if (!empty($full_row_ann_selected)) : ?>
+  <?php $ann_cats = rwmb_meta('phila_get_ann_cats');
+    $ann_cat_override = isset($ann_cats['phila_announcement_category']) ? $ann_cats['phila_announcement_category'] : '';
+    $ann_tag_override = isset($ann_override['ann_tag']) ? $ann_override['ann_tag'] : ''; ?>
+
+  <!-- Announcement Content-->
+  <section class="announcements">
+    <?php include(locate_template('partials/global/phila_full_row_announcements.php')); ?>
+  </section>
+  <!-- /Announcement Content-->
+<?php endif; ?>
 
 <?php if (!empty($full_row_blog_selected)) : ?>
   <?php $blog_override = rwmb_meta('phila_get_post_cats');

--- a/wp/wp-content/themes/phila.gov-theme/partials/posts/announcements-grid.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/posts/announcements-grid.php
@@ -82,7 +82,7 @@
         <?php $post_obj = get_post_type_object( $post_type ); ?>
             <div class="cell medium-<?php echo phila_grid_column_counter( $count ) ?> align-self-stretch">
               <?php if ($user_selected_template == 'custom_content' || $post_type_parent === 'guides'): ?>
-                <?php include( locate_template( 'partials/posts/custom-content-card.php' ) ); ?>
+                <?php include( locate_template( 'partials/posts/content-card.php' ) ); ?>
               <?php else: ?>
                 <?php include( locate_template( 'partials/posts/content-card.php' ) ); ?>
               <?php endif; ?>

--- a/wp/wp-content/themes/phila.gov-theme/templates/single-on-site-content.php
+++ b/wp/wp-content/themes/phila.gov-theme/templates/single-on-site-content.php
@@ -116,9 +116,9 @@ HTML;
           'tag' => !empty($_tags_override['tag']) ? $_tags_override['tag'] : ''
         ),
 
-        'full_row_news'   => array(
-            'exists'=> rwmb_meta( 'phila_full_row_news_selected' ),
-            'category_id' => !empty($_news_cat_override) ? implode(", ", $_news_cat_override['phila_news_category']) : $_categories[0]->cat_ID
+        'full_row_announcements'   => array(
+          'exists'=> rwmb_meta('phila_full_row_announcements_selected' ),
+          'tag' => !empty($_tags_override['tag']) ? $_tags_override['tag'] : ''
         ),
 
         'full_width_press_releases'=>array(


### PR DESCRIPTION
This also: 
- Prevents timeline markup from appearing on every page, regardless of if its inclusion. 
- Fixes staff directory spacing on a department homepage. 