### PR TITLE
Correct image check

### DIFF
--- a/wp/wp-content/themes/phila.gov-theme/partials/departments/v2/photo-callout.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/departments/v2/photo-callout.php
@@ -12,8 +12,8 @@ if (phila_get_selected_template() === 'homepage_v2') {
     $btnIcon = rwmb_meta('phila_v2_photo_callout_block__icon');
     $icon = rwmb_meta('phila_v2_photo-callout-block__txt-icon');
     $get_photo = rwmb_meta('phila_v2_photo_callout_block__photo');
-    $photo = isset(reset($get_photo)['full_url']);
-    $alt = isset(reset($get_photo)['alt']);
+    $photo = (reset($get_photo)['full_url'] !== null ? reset($get_photo)['full_url'] : '' );
+    $alt = (reset($get_photo)['alt'] !== null ? reset($get_photo)['alt'] : '');
 } else {
     $photo_callout = isset($current_row['phila_full_options']['photo_callout']) ? $current_row['phila_full_options']['photo_callout'] : '';
     $toggle = isset($photo_callout['phila_v2_photo_callout_block__image_toggle']) ? $photo_callout['phila_v2_photo_callout_block__image_toggle'] : '';


### PR DESCRIPTION
This removes an isset() on the photo value and replaces it with a "null" check. This should prevent warnings in dev and correctly display the image in production.