### PR TITLE
unlisted authors

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-post.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-post.php
@@ -41,6 +41,7 @@ class Phila_Gov_Post {
         array(
           'id'  => 'phila_author_group',
           'type' => 'group',
+          'desc'  => 'byline reminder to subscribe frequent guest authors',
           'clone'  => true,
           'sort_clone' => true,
           'add_button' => '+ Add author',

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-post.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-post.php
@@ -41,7 +41,7 @@ class Phila_Gov_Post {
         array(
           'id'  => 'phila_author_group',
           'type' => 'group',
-          'desc'  => 'byline reminder to subscribe frequent guest authors',
+          'desc'  => 'Use this feature to manually enter an authors name. If a person will author several posts, you should instead request that they get byline access in WordPress.',
           'clone'  => true,
           'sort_clone' => true,
           'add_button' => '+ Add author',

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-post.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-post.php
@@ -51,8 +51,7 @@ class Phila_Gov_Post {
               'id'   => 'phila_additional_author',
               'type' => 'text',
               'desc'  => 'The author of this post will be listed first, with authors chosen here appearing after, in the order listed.',
-              'size' => 50,
-              'columns' => 12,
+              'size' => 50
             ),
           )
         )

--- a/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-post.php
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/meta-boxes/class-phila-gov-post.php
@@ -28,10 +28,33 @@ class Phila_Gov_Post {
           'id'  => 'phila_author',
           'type' => 'user',
           'multiple' => true,
+          'hidden' => true,
           'field_type'  => 'select_advanced',
           'placeholder' => 'Select more authors',
           'desc'  => 'The author of this post will be listed first, with authors chosen here appearing after, in the order listed.'
       ),
+        array(
+          'id'  => 'phila_exclude_author',
+          'type'  => 'checkbox',
+          'name'  => 'Exclude default author from list?'
+        ),
+        array(
+          'id'  => 'phila_author_group',
+          'type' => 'group',
+          'clone'  => true,
+          'sort_clone' => true,
+          'add_button' => '+ Add author',
+          'fields' => array(
+            array(
+              'name' => 'Additional author',
+              'id'   => 'phila_additional_author',
+              'type' => 'text',
+              'desc'  => 'The author of this post will be listed first, with authors chosen here appearing after, in the order listed.',
+              'size' => 50,
+              'columns' => 12,
+            ),
+          )
+        )
     )
   );
 

--- a/wp/wp-content/themes/phila.gov-theme/functions.php
+++ b/wp/wp-content/themes/phila.gov-theme/functions.php
@@ -612,7 +612,7 @@ function phila_get_posted_on(){
   $exclude_author = rwmb_meta('phila_exclude_author');
   $author_group = rwmb_meta('phila_author_group');
   $more_authors = rwmb_meta('phila_author'); // deprecated, now hidden on admin
-  $exclude_author ? $posted_on_meta['author'] = [] : $posted_on_meta['author'] = array( esc_html( get_the_author()));
+  $exclude_author ? $posted_on_meta['author'] = [] : $posted_on_meta['author'] = array( esc_html( get_userdata(get_post_field ('post_author', get_the_ID()))->display_name ));
   if ( !empty($author_group) ) {
     foreach ($author_group as $author) {
       array_push($posted_on_meta['author'], $author['phila_additional_author']);

--- a/wp/wp-content/themes/phila.gov-theme/functions.php
+++ b/wp/wp-content/themes/phila.gov-theme/functions.php
@@ -609,9 +609,15 @@ function phila_get_dept_contact_blocks() {
 
 
 function phila_get_posted_on(){
-  $posted_on_meta['author'] = array( esc_html( get_the_author()));
-  $more_authors = rwmb_meta('phila_author');
-  if ( !empty($more_authors) ) {
+  $exclude_author = rwmb_meta('phila_exclude_author');
+  $author_group = rwmb_meta('phila_author_group');
+  $more_authors = rwmb_meta('phila_author'); // deprecated, now hidden on admin
+  $exclude_author ? $posted_on_meta['author'] = [] : $posted_on_meta['author'] = array( esc_html( get_the_author()));
+  if ( !empty($author_group) ) {
+    foreach ($author_group as $author) {
+      array_push($posted_on_meta['author'], $author['phila_additional_author']);
+    }
+  } else if ( !empty($more_authors) ) {
     foreach ($more_authors as $author) {
       $user = get_userdata($author);
       array_push($posted_on_meta['author'], $user->display_name);

--- a/wp/wp-content/themes/phila.gov-theme/partials/errors/post-errors.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/errors/post-errors.php
@@ -10,7 +10,8 @@ if ( is_user_logged_in() && (phila_get_selected_template() == 'post' || phila_ge
     array_push($error_messages, $item1);
     array_push($error_messages, $item2);
   }
-  if ( empty($posted_on_meta['author'])) {
+  $posted_on_values = phila_get_posted_on();
+  if ( empty($posted_on_values['author'])) {
     $error_message_title = "Warning: This blog post doesn't have an author attributed to it.";
     $error_messages = [];
     $item1['link'] = '';

--- a/wp/wp-content/themes/phila.gov-theme/partials/errors/post-errors.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/errors/post-errors.php
@@ -1,12 +1,22 @@
 <?php 
-if ( is_user_logged_in() ) {
-  if ( !has_post_thumbnail() && (phila_get_selected_template() == 'post' || phila_get_selected_template() == 'translated_post') ) {
+if ( is_user_logged_in() && (phila_get_selected_template() == 'post' || phila_get_selected_template() == 'translated_post') ) {
+  if ( !has_post_thumbnail()) {
     $error_message_title = "Warning: This blog post doesn't have a featured image.";
     $error_messages = [];
     $item1['link'] = '';
     $item1['text'] = '<p>All blog posts must have a featured image according to the <a href="https://standards.phila.gov/docs/content/how-to-write-a-blog.html">phila.gov digital standards</a>.</p>';
     $item2['link'] = '';
     $item2['text'] = "<p>If you don't have an image, you can use one of these <a href='https://drive.google.com/drive/folders/1w7RAaf5LYVH-mozpRbD5hERSt-S3w6Wa'>general use images</a>.</p>";
+    array_push($error_messages, $item1);
+    array_push($error_messages, $item2);
+  }
+  if ( empty($posted_on_meta['author'])) {
+    $error_message_title = "Warning: This blog post doesn't have an author attributed to it.";
+    $error_messages = [];
+    $item1['link'] = '';
+    $item1['text'] = '<p>All blog posts must have at least one author attributed to the post.</p>';
+    $item2['link'] = '';
+    $item2['text'] = "<p>If there are no additional authors, make sure the 'Exclude default author from list?' checkbox is unchecked.</p>";
     array_push($error_messages, $item1);
     array_push($error_messages, $item2);
   }


### PR DESCRIPTION
The deprecated phila_author field needs to be hidden rather than removed. When its deleted, it returns a single string of the first item in the array of items that should be returned. 

ex returned when hidden
array(2) { [0]=> string(3) "180" [1]=> string(3) "304" }

ex returned when deleted
"180"