### PR TITLE
stops on click within translations menu

### DIFF
--- a/wp/wp-content/themes/phila.gov-theme/js/dev/phila-gov.js
+++ b/wp/wp-content/themes/phila.gov-theme/js/dev/phila-gov.js
@@ -236,7 +236,7 @@ module.exports = $(function () {
           });
         },
         'click': function() {
-            $(this).find('.menu').toggle();
+            $(this).find('.menu').children(':not(.show-for-medium)').toggle();
             if ($(this).find('#lang-dropdown').css('display') === 'none') {
                 $(this).removeClass('menu-open');
               } else {
@@ -247,7 +247,6 @@ module.exports = $(function () {
 
     $(document).on('click', function(event) {
         if (!$(event.target).closest('#translations-menu').length) {
-          $('#translations-menu .menu').hide();
           $('#translations-menu').removeClass('menu-open');
         }
     });


### PR DESCRIPTION
Prevents on click event menu dropdown on desktop items when translation menu is clicked. 

https://www.wrike.com/workspace.htm?acc=2747306#folder/432990175/board?overlayEntityId=1087205364&sortOrder=10&spaceId=453350584&viewId=3978741