### PR TITLE
Correct emails addresses and show publish button for page editors

### DIFF
--- a/wp/wp-content/plugins/phila.gov-customization/admin/js/admin-department-author.js
+++ b/wp/wp-content/plugins/phila.gov-customization/admin/js/admin-department-author.js
@@ -29,7 +29,7 @@ jQuery(document).ready(function($){
 
 
   //If department "contributor" doesn't have access to this post type, hide the publish button, allow publishing action on document pages
-  if ( ( typenow != 'document') && adminpage.indexOf('post') > -1 ){
+  if ( ( typenow != 'document') && ( typenow != 'page') && adminpage.indexOf('post') > -1 ){
     phila_WP_User.some(
       function(v){
         if ( v.indexOf(typenow) >= 0) {
@@ -43,7 +43,7 @@ jQuery(document).ready(function($){
 
   //Hide all category and tag menu items, department authors shouldn't see those.
 $('a[href="edit-tags.php?taxonomy=category&post_type=calendar"]').parent().css("display", "none");
-  
+
   var menuIdString = $('#menu-id').text().trim();
   var allMenuIDs = menuIdString.split(' ');
   var match = document.getElementById( allMenuIDs );
@@ -95,7 +95,7 @@ $('a[href="edit-tags.php?taxonomy=category&post_type=calendar"]').parent().css("
     if ( ( typenow == 'department_page') && adminpage.indexOf('post') > -1 ){
       $('[id^=phila_block_id]').parent().parent().hide();
       //hide short description and let users know what they can do to change it
-      $('#phila_meta_desc').after( "<i>To request a change to the short description, email <a href='mailto:oddt@phila.gov'>oddt@phila.gov</a>.</i>" )
+      $('#phila_meta_desc').after( "<i>To request a change to the short description, email <a href='mailto:websupport@phila.gov'>websupport@phila.gov</a>.</i>" )
     }
   }
 
@@ -117,7 +117,7 @@ $('a[href="edit-tags.php?taxonomy=category&post_type=calendar"]').parent().css("
   }
 
   if ( ( typenow == 'programs') && adminpage.indexOf('post') > -1 ){
-    $('#phila_meta_desc').after( "<i>To request a change to the short description, email <a href='mailto:oddt@phila.gov'>oddt@phila.gov</a>.</i>" )
+    $('#phila_meta_desc').after( "<i>To request a change to the short description, email <a href='mailto:websupport@phila.gov'>websupport@phila.gov</a>.</i>" )
   }
 
   if ( ( typenow == 'post') && adminpage.indexOf('post') > -1 ){
@@ -155,7 +155,7 @@ $('a[href="edit-tags.php?taxonomy=category&post_type=calendar"]').parent().css("
   }
   if ( ( typenow == 'department_page') && adminpage.indexOf('post') > -1 ){
 
-    $('#wp-module_row_1_col_1_module_row_1_col_1_options_phila_module_row_1_col_1_textarea-wrap').after( "<i>To request a change to 'What we do' content, email <a href='mailto:oddt@phila.gov'>oddt@phila.gov</a>.</i>" )
+    $('#wp-module_row_1_col_1_module_row_1_col_1_options_phila_module_row_1_col_1_textarea-wrap').after( "<i>To request a change to 'What we do' content, email <a href='mailto:websupport@phila.gov'>websupport@phila.gov</a>.</i>" )
 
   }
 


### PR DESCRIPTION
This fixes the email address in the WordPress admin to be "websupport" and it adds the "publish" button back to the "page" content type, from which it was missing. 