### PR TITLE
refactor: Fix brittle logic on Mayor's page

### DIFF
--- a/wp/wp-content/themes/phila.gov-theme/single-department_page.php
+++ b/wp/wp-content/themes/phila.gov-theme/single-department_page.php
@@ -15,10 +15,12 @@ global $post;
 function get_dept_partial($partial_name, $partial_args = array()){
   global $post;
 
-  if ( $post->ID == '4099' ){
-    include(locate_template(('partials/departments/v2/mayor/home.php')));
+  $parent = wp_get_post_parent_id($post);
+  $parent_post_name = wp_get_post_parent_name($parent);
 
-  } else if ($post->post_parent == '4099'){
+  if ( $post->post_name == 'mayor' ){
+    include(locate_template(('partials/departments/v2/mayor/home.php')));
+  } else if ($parent_post_name == 'mayor'){
     include(locate_template(('partials/departments/v2/mayor/subpage.php')));
   }
   else{
@@ -36,13 +38,11 @@ $children = get_posts( array(
 ));
 
 $ancestors = get_post_ancestors($post);
-$parent = wp_get_post_parent_id($post);
 $user_selected_template = phila_get_selected_template();
 
 get_header(); ?>
 
 <div id="post-<?php the_ID(); ?>" <?php post_class('department clearfix ' . $user_selected_template); ?>>
-
   <?php
 
     $parent = phila_util_get_furthest_ancestor($post);

--- a/wp/wp-includes/post.php
+++ b/wp/wp-includes/post.php
@@ -7902,6 +7902,30 @@ function wp_get_post_parent_id( $post = null ) {
 }
 
 /**
+ * Returns the post_name of the post's parent.
+ *
+ * @since 3.1.0
+ * @since 5.9.0 The `$post` parameter was made optional.
+ *
+ * @param int|WP_Post|null $post Optional. Post ID or post object. Defaults to global $post.
+ * @return string|false Post parent post_name (which can be '' if there is no parent),
+ *                   or false if the post does not exist.
+ */
+function wp_get_post_parent_name( $post_parent = null ) {
+	$post_parent = get_post( $post_parent );
+
+	if ( ! $post_parent || is_wp_error( $post_parent ) ) {
+		return false;
+	}
+
+	if ( $post_parent == 0) {
+		return '';
+	}
+
+	return (string) post_parent->post_name;
+}
+
+/**
  * Checks the given subset of the post hierarchy for hierarchy loops.
  *
  * Prevents loops from forming and breaks those that it finds. Attached


### PR DESCRIPTION
Currently, we apply the special 2024-redesign template by checking the post_id. This is brittle because the page id can vary across environments. 

This fix does the same check by matching against the post_name (which in this case should be 'mayor'.) That value seemed like the most intuitive and also stable for our purposes. 

To accomplish this, I added a method `wp_get_post_parent_name` into `post.php` which mirrors the method above it, `wp_get_post_parent_id`. 