### PR TITLE
fixed header on subpages with association

### DIFF
--- a/wp/wp-content/themes/phila.gov-theme/partials/programs/header.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/programs/header.php
@@ -70,7 +70,7 @@
         </div>
       </div>
     </div>
-    <?php if ($user_selected_template != 'prog_association') : ?>
+    <?php if ($user_selected_template != 'prog_association' && phila_get_selected_template($ancestors[0]) != 'prog_association') : ?>
       <?php phila_get_menu(); ?>
     <?php endif; ?>
     <?php if ($current_post_type != 'department_page' && $user_selected_template != 'stub') : ?>

--- a/wp/wp-content/themes/phila.gov-theme/single-department_page.php
+++ b/wp/wp-content/themes/phila.gov-theme/single-department_page.php
@@ -38,6 +38,7 @@ $children = get_posts( array(
 $ancestors = get_post_ancestors($post);
 $parent = wp_get_post_parent_id($post);
 $user_selected_template = phila_get_selected_template();
+$parent_template = phila_get_selected_template($parent);
 
 get_header(); ?>
 
@@ -46,8 +47,7 @@ get_header(); ?>
   <?php
 
     $parent = phila_util_get_furthest_ancestor($post);
-
-    if ( phila_util_is_new_template( $parent->ID ) && $user_selected_template !== 'prog_association' ) :
+    if ( phila_util_is_new_template( $parent->ID ) && $user_selected_template !== 'prog_association' && $parent_template !== 'prog_association' ) :
       /**
        * Department Homepage V2 Hero
        */


### PR DESCRIPTION
**Issue** - Child pages under template type "Subpage with association" are displaying parent page header instead of immediate ancestor header. 

Example - 
| Page | Template | Link |
| ----- | --------- | ---- |
| Parent Page | Homepage | [https://www.phila.gov/departments/office-of-the-director-of-finance/](url) | 
| 1st Child Page | Subpage with association | [https://www.phila.gov/departments/office-of-the-director-of-finance/cdbg-dr-program/](url) | 
| 2nd Child Page | Document finder | [https://www.phila.gov/departments/office-of-the-director-of-finance/cdbg-dr-program/action-plan-and-related-documents/](url) | 

Ideally, 2nd child should inherit the header from 1st child but it is defaulting to the parent's header. 

**Fix** - 
In `wp/wp-content/themes/phila.gov-theme/single-department_page.php`, we first set the parent template type to variable `$parent_template`. 
Then, if the `$parent_template !== 'prog_association'` which means we are checking that the 1st child page template is not **subpage with association** and then setting header to department header v2 else setting the header to programs header.
The programs header is coded in a way that it picks up the 1st child page header and sets that to the 2nd child page header. 

In `wp/wp-content/themes/phila.gov-theme/partials/programs/header.php`, we added a check `phila_get_selected_template($ancestors[0]) != 'prog_association'` which means we are checking if the 2nd child page template is not **subpage with association** in order to not display the submenu.

**TL;DR** - Check 2nd child page template, if **subpage with association** - set programs header and do not display submenu.