### PR TITLE
[fix] add year to date range for event spotlight

### DIFF
--- a/wp/wp-content/themes/phila.gov-theme/partials/event-spotlight/header.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/event-spotlight/header.php
@@ -50,7 +50,7 @@
                   echo $date_output;
                   ?>
                 <?php else :?>
-                  <?php $date_output = str_replace(array('Sep'), array('Sept'), $start->format('l, ' . $start_month_format . ' j') . ' - ' . $end->format( 'l, ' . $end_month_format . ' j, Y') );
+                  <?php $date_output = str_replace(array('Sep'), array('Sept'), $start->format('l, ' . $start_month_format . ' j, Y') . ' - ' . $end->format( 'l, ' . $end_month_format . ' j, Y') );
                   echo $date_output;
                   ?>
 
@@ -75,7 +75,7 @@
                   <?php else : ?>
                     <?php $date_output = str_replace(
                       array('Sep','12:00 am','12:00 pm','am','pm',':00'),
-                      array('Sept','midnight','noon','a.m.','p.m.',''), $start->format('l, ' . $start_month_format . ' j') . ' - ' . $end->format('l, ' . $end_month_format . ' j, Y' ) .  '<br />'. $start->format('g:i a') . ' - '  . $end->format('g:i a'));
+                      array('Sept','midnight','noon','a.m.','p.m.',''), $start->format('l, ' . $start_month_format . ' j, Y') . ' - ' . $end->format('l, ' . $end_month_format . ' j, Y' ) .  '<br />'. $start->format('g:i a') . ' - '  . $end->format('g:i a'));
                       echo $date_output;
                       ?>
                       <i class="fas fa-sync" aria-hidden="true"></i> Recurring daily

--- a/wp/wp-content/themes/phila.gov-theme/templates/single-post.php
+++ b/wp/wp-content/themes/phila.gov-theme/templates/single-post.php
@@ -103,8 +103,7 @@ if ((empty( $archived ) || !isset($archived) || $archived == 'default') &&  $pos
   <?php if ( has_post_thumbnail() && ($template_type != 'action_guide') && ($template_type != 'press_release') ): ?>
     <div class="grid-container featured-image <?php echo $language == 'arabic' ? $language : '' ?>">
       <div class="grid-x medium-16 medium-centered align-middle">
-        <?php if( strpos(phila_get_thumbnails(), 'phila-thumb') || strpos(phila_get_thumbnails(), 'phila-news')  ) : 
-          var_dump(phila_get_thumbnails()); ?>
+        <?php if( strpos(phila_get_thumbnails(), 'phila-thumb') || strpos(phila_get_thumbnails(), 'phila-news')  ) : ?>
           <div class="js-thumbnail-image">
             <div class="lightbox-link lightbox-link--feature" data-open="phila-lightbox-feature">
               <?php echo phila_get_thumbnails(); ?>


### PR DESCRIPTION
# WHY
The Mayor's Comms team flagged that the date range for this spotlight actually spans two years, but that the date range display suppresses the year for the start date. They want the year to be displayed for the start date. Zari Tarazona has confirmed for the content team that it is fine for the year to be visible on all event spotlights.

# HOW
In the event-spotlight card partial, the date format omits the year from the start date:
`$start->format('l, ' . $start_month_format . ' j')`. We add `Y` to the start_month_format so that the year will be visible.

# BEFORE (observed behavior)
<img width="748" height="755" alt="Screenshot 2026-08-07 at 3 30 15 PM" src="https://github.com/user-attachments/assets/f0c93147-3ca5-477e-8cba-88011e88a680" />

# AFTER (corrected behavior)
<img width="760" height="599" alt="Screenshot 2026-08-07 at 3 28 11 PM" src="https://github.com/user-attachments/assets/5e742214-1861-47fc-80ae-6b1cc4b2ad36" />

# TO TEST BEHAVIOR
If you're running phila.gov locally, check out this branch and load http://philagov.local/spotlight/christmas-village-in-philadelphia/. You should be able to see the above behavior demonstrated.