### PR TITLE
[fix] add year to date range for event spotlight

### DIFF
--- a/wp/wp-content/themes/phila.gov-theme/partials/event-spotlight/header.php
+++ b/wp/wp-content/themes/phila.gov-theme/partials/event-spotlight/header.php
@@ -50,7 +50,7 @@
                   echo $date_output;
                   ?>
                 <?php else :?>
-                  <?php $date_output = str_replace(array('Sep'), array('Sept'), $start->format('l, ' . $start_month_format . ' j') . ' - ' . $end->format( 'l, ' . $end_month_format . ' j, Y') );
+                  <?php $date_output = str_replace(array('Sep'), array('Sept'), $start->format('l, ' . $start_month_format . ' j, Y') . ' - ' . $end->format( 'l, ' . $end_month_format . ' j, Y') );
                   echo $date_output;
                   ?>
 
@@ -75,7 +75,7 @@
                   <?php else : ?>
                     <?php $date_output = str_replace(
                       array('Sep','12:00 am','12:00 pm','am','pm',':00'),
-                      array('Sept','midnight','noon','a.m.','p.m.',''), $start->format('l, ' . $start_month_format . ' j') . ' - ' . $end->format('l, ' . $end_month_format . ' j, Y' ) .  '<br />'. $start->format('g:i a') . ' - '  . $end->format('g:i a'));
+                      array('Sept','midnight','noon','a.m.','p.m.',''), $start->format('l, ' . $start_month_format . ' j, Y') . ' - ' . $end->format('l, ' . $end_month_format . ' j, Y' ) .  '<br />'. $start->format('g:i a') . ' - '  . $end->format('g:i a'));
                       echo $date_output;
                       ?>
                       <i class="fas fa-sync" aria-hidden="true"></i> Recurring daily


### PR DESCRIPTION
# WHAT
Moving changes from staging to main. Previous pull request (from feature branch to staging) can be seen here: https://github.com/CityOfPhiladelphia/phila.gov/pull/2355

# HOW 
Having verified the changes on main, we want to move this one commit onto main. (We don't want to pull anything accidental over with us due to any mismatches between staging and main.) 

# TEST
To verify the behavior, please visit the following event spotlight in staging (you should see the year displayed for both the start and end date, as shown below. There should be no other changes): https://staging-admin.phila.gov/wp-admin/post.php?post=435847&action=edit

# OBSERVED BEHAVIOR:
<img width="1192" height="934" alt="image" src="https://github.com/user-attachments/assets/17b08b4d-d178-4409-b617-5e2e584ed93a" />
